### PR TITLE
slack-post-msg v1.0.4 - Allow custon display icon 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - id: compute_tag
+        uses: craig-day/compute-tag@v10
+        with:
+          github_token: ${{ github.token }}
+          version_type: patch

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: compute_tag
-        uses: craig-day/compute-tag@v10
+        uses: zendesk/compute-tag@v10
         with:
           github_token: ${{ github.token }}
           version_type: patch

--- a/samson-create-release/Dockerfile
+++ b/samson-create-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM curlimages/curl:7.69.1
+FROM curlimages/curl:7.71.1
 
 LABEL "com.github.actions.name"="Create Samson releases"
 LABEL "com.github.actions.description"="create samson releases"

--- a/samson-create-release/Dockerfile
+++ b/samson-create-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM curlimages/curl:7.68.0
+FROM curlimages/curl:7.69.1
 
 LABEL "com.github.actions.name"="Create Samson releases"
 LABEL "com.github.actions.description"="create samson releases"

--- a/slack-post-msg/Dockerfile
+++ b/slack-post-msg/Dockerfile
@@ -5,7 +5,7 @@ LABEL "com.github.actions.description"="Post Slack messages from your own bot"
 LABEL "com.github.actions.icon"="hash"
 LABEL "com.github.actions.color"="gray-dark"
 
-LABEL version="1.0.3"
+LABEL version="1.0.4"
 LABEL repository="http://github.com/zendesk/ga/slack-post-msg"
 LABEL homepage="http://github.com/zendesk/ga/slack-post-msg"
 LABEL maintainer="Engineering Productivity"

--- a/slack-post-msg/README.md
+++ b/slack-post-msg/README.md
@@ -5,6 +5,7 @@ This action wraps the Slack [chat.postMessage](https://api.slack.com/methods/cha
 ## Env variables
 - *SLACK_BOT_TOKEN* (required)
 - *GITHUB_CONTEXT* (required)
+- *ICON* (options, default: github-buddy)
 - *STATUS* (optional) valid values are failure and success, default is failure
 - *CHANNEL_ID* (required)
 If you open Slack in your web browser, you can find channel IDs at the end of the URL when viewing channels and private groups. Note that this doesn't work for direct messages.

--- a/slack-post-msg/entrypoint.sh
+++ b/slack-post-msg/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 
 STATUS=${STATUS:-failure}
+DISPLAY=${ICON:-github-buddy}
 
 if test -z "$SLACK_BOT_TOKEN"; then
   echo "Set the SLACK_BOT_TOKEN secret."
@@ -49,7 +50,7 @@ body=$(cat <<EOF
 {
     "channel": "$CHANNEL_ID",
     "text": "The run *#$run_no* has $result in $repository \n Commit:$short_sha Pushed by $actor URL:$run_url",
-    "icon_emoji": ":github-buddy:",
+    "icon_emoji": ":$DISPLAY:",
     "username": "GitHub Actions Bot",
     "blocks": [
     {


### PR DESCRIPTION
- Add release workflow
- pass ICON as an env var 
- Upgrade curl image version to 7.71.1