### PR TITLE
Use our own release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,20 +7,11 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted,zendesk-stable]
     steps:
-      - name: Compute tag
-        id: compute_tag
-        uses: zendesk/compute-tag@v10
+      - uses: zendesk/checkout@v2
+      - uses: zendesk/ga/tag-semantic-release@v2
+        id: tag
         with:
-          github_token: ${{ github.token }}
-          version_type: patch
-      - name: Create release
-        uses: zendesk/create-release@v1
-        with:
-          tag_name: ${{ steps.compute_tag.outputs.next_tag }}
-          release_name: ${{ steps.compute_tag.outputs.next_tag }}
-          body: >
-            Automatic release of ${{ steps.compute_tag.outputs.next_tag }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version-type: patch

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: [self-hosted,zendesk-stable]
+    runs-on: ubuntu-latest
     steps:
       - uses: zendesk/checkout@v2
       - uses: zendesk/ga/tag-semantic-release@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - uses: zendesk/checkout@v2
       - uses: zendesk/ga/tag-semantic-release@v2
-        id: tag
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version-type: patch


### PR DESCRIPTION
Update the release workflow to use tag-semantic-release action.
This is a success dry-run: https://github.com/zendesk/ga/actions/runs/215901444