### PR TITLE
Using longopts with `jq`

### DIFF
--- a/samson-inbound-webhook/action.yaml
+++ b/samson-inbound-webhook/action.yaml
@@ -37,10 +37,12 @@ runs:
         fi
 
         # call webhook
-        payload=$(jq -cn \
+        payload=$(jq \
           --arg branchName "$branchName" \
           --arg message "${{ inputs.message }}" \
           --arg sha "${{ github.sha }}" \
+          --compact-output \
+          --null-input \
             '{deploy: {branch: $branchName,commit: {message: $message,sha: $sha}}}'
         )
 


### PR DESCRIPTION
Making use of long options with `jq` for verbosity with the Samson inbound webhook action.