### PR TITLE
Add workflow name to notification title

### DIFF
--- a/slack-post-msg/payload.json
+++ b/slack-post-msg/payload.json
@@ -1,14 +1,14 @@
 {
   "channel": $channel,
   "icon_emoji": [":",$emoji,":"] | join(""),
-  "text": ["Run #",$runNumber," ",$resultMessagePre," ",$resultMessage," for ",$repositoryName," Commit: ",$commitSha," Actor: ",$actor] | join(""),
+  "text": [$workflowName," run #",$runNumber," ",$resultMessagePre," ",$resultMessage," for ",$repositoryName," Commit: ",$commitSha," Actor: ",$actor] | join(""),
   "username": $username,
   "blocks": [
     {
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": ["Run *#",$runNumber,"* ",$resultMessagePre," *",$resultMessage,"* for `",$repositoryName,"`"] | join(""),
+        "text": ["*",$workflowName,"* run *#",$runNumber,"* ",$resultMessagePre," *",$resultMessage,"* for `",$repositoryName,"`"] | join(""),
       }
     },
     {


### PR DESCRIPTION
When we have multiple workflows on the same PR (eg. Unit tests and UI tests) it would be useful and faster to see what notification belongs to what workflow.