### PR TITLE
Make use of `github.head_ref` in place of `github.event.pull_request.head.ref`

### DIFF
--- a/samson-inbound-webhook/action.yaml
+++ b/samson-inbound-webhook/action.yaml
@@ -28,7 +28,7 @@ runs:
         branchName="${{ inputs.branch }}"
         if [[ -z $branchName ]]; then
           # extract branch name (either pull request head or workflow trigger)
-          branchName="${{ github.event.pull_request.head.ref }}"
+          branchName="${{ github.head_ref }}"
           if [[ -z $branchName ]]; then
             # not a pull request workflow run
             branchName="${{ github.ref }}"

--- a/slack-post-msg/action.yaml
+++ b/slack-post-msg/action.yaml
@@ -47,7 +47,7 @@ runs:
         commitSha="${{ github.sha }}"
 
         # extract branch name (either pull request head or workflow trigger)
-        branchName="${{ github.event.pull_request.head.ref }}"
+        branchName="${{ github.head_ref }}"
         if [[ -z $branchName ]]; then
           # not a pull request workflow run
           branchName="${{ github.ref }}"


### PR DESCRIPTION
The value of `github.head_ref` (which only exists for PR runs) is identical to `github.event.pull_request.head.ref` - so lets use the less verbose property.

[Reference](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context)