### PR TITLE
[tag-semantic-release] Add an ability to attach assets to a new release

### DIFF
--- a/tag-semantic-release/README.md
+++ b/tag-semantic-release/README.md
@@ -6,6 +6,7 @@ A GitHub Action to create a semantic releases for your default branch.
 - *github-token* (required)
 - *debug* (optional, default: false)
 - *dry-run* (optional, default: false)
+- *assets* (optional, file names are space delimited)
 
 ## Example
 ```yaml

--- a/tag-semantic-release/action.yaml
+++ b/tag-semantic-release/action.yaml
@@ -8,7 +8,7 @@ inputs:
   github-token:
     required: true
   assets:
-    default: none
+    default: ""
   debug:
     default: false
   dry-run:
@@ -79,7 +79,7 @@ runs:
         echo "New tag: $new_tag"
 
         if [ ${{ inputs.dry-run }} = false ]; then
-          if [[ ${{ inputs.assets }} != none ]]; then
+          if [[ -n ${{ inputs.assets }} ]]; then
             assets=()
             for f in ${{ inputs.assets }}; do && assets+=(-a "$f"); done
             hub release create "${assets[@]}" -m "Release $new_tag" "$new_tag"

--- a/tag-semantic-release/action.yaml
+++ b/tag-semantic-release/action.yaml
@@ -79,9 +79,9 @@ runs:
         echo "New tag: $new_tag"
 
         if [ ${{ inputs.dry-run }} = false ]; then
-          if [[ -n ${{ inputs.assets }} ]]; then
+          if [ -n ${{ inputs.assets }} ]; then
             assets=()
-            for f in ${{ inputs.assets }}; do && assets+=(-a "$f"); done
+            for f in ${{ inputs.assets }}; do assets+=(-a "$f"); done
             hub release create "${assets[@]}" -m "Release $new_tag" "$new_tag"
           else
             hub release create -m "Release $new_tag" $new_tag

--- a/tag-semantic-release/action.yaml
+++ b/tag-semantic-release/action.yaml
@@ -79,7 +79,7 @@ runs:
         echo "New tag: $new_tag"
 
         if [ ${{ inputs.dry-run }} = false ]; then
-          if [ -n ${{ inputs.assets }} ]; then
+          if [ -n "${{ inputs.assets }}" ]; then
             assets=()
             for f in ${{ inputs.assets }}; do assets+=(-a "$f"); done
             hub release create "${assets[@]}" -m "Release $new_tag" "$new_tag"

--- a/tag-semantic-release/action.yaml
+++ b/tag-semantic-release/action.yaml
@@ -7,6 +7,8 @@ inputs:
     default: patch
   github-token:
     required: true
+  assets:
+    default: none
   debug:
     default: false
   dry-run:
@@ -77,7 +79,13 @@ runs:
         echo "New tag: $new_tag"
 
         if [ ${{ inputs.dry-run }} = false ]; then
-          hub release create -m "$new_tag" $new_tag
+          if [[ ${{ inputs.assets }} != none ]]; then
+            assets=()
+            for f in ${{ inputs.assets }}; do && assets+=(-a "$f"); done
+            hub release create "${assets[@]}" -m "Release $new_tag" "$new_tag"
+          else
+            hub release create -m "Release $new_tag" $new_tag
+          fi
         fi
       shell: bash
       id: main


### PR DESCRIPTION
#Changes:
- added a new optional input called `assets`
- able to upload more than one asset.
- the assets input is space-delimited e.g. `file1 file2 file3`

## Example
```
      - name: Create a release
        uses: zendesk/ga/tag-semantic-release@shoukoo.upload-asset
        id: tag
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          version-type: patch
          assets: "bee-stable bee-classic"
```