### PR TITLE
Support pre-release in tag-semantic-release 

### DIFF
--- a/tag-semantic-release/README.md
+++ b/tag-semantic-release/README.md
@@ -2,11 +2,12 @@
 A GitHub Action to create a semantic releases for your default branch.
 
 ## Parameters
-- *version-type* (required, options: major, minor or patch)
-- *github-token* (required)
+- *assets* (optional, file names are space delimited)
 - *debug* (optional, default: false)
 - *dry-run* (optional, default: false)
-- *assets* (optional, file names are space delimited)
+- *github-token* (required)
+- *pre-release* (optional, default: false)
+- *version-type* (required, options: major, minor or patch)
 
 ## Example
 ```yaml

--- a/tag-semantic-release/action.yaml
+++ b/tag-semantic-release/action.yaml
@@ -4,11 +4,12 @@ author: Andy Hsieh
 inputs:
   version-type:
     required: true
-    default: patch
   github-token:
     required: true
   assets:
     default: ""
+  pre-release:
+    default: false
   debug:
     default: false
   dry-run:
@@ -79,13 +80,17 @@ runs:
         echo "New tag: $new_tag"
 
         if [ ${{ inputs.dry-run }} = false ]; then
+          options=()
+
           if [ -n "${{ inputs.assets }}" ]; then
-            assets=()
-            for f in ${{ inputs.assets }}; do assets+=(-a "$f"); done
-            hub release create "${assets[@]}" -m "Release $new_tag" "$new_tag"
-          else
-            hub release create -m "Release $new_tag" $new_tag
+            for f in ${{ inputs.assets }}; do options+=(-a "$f"); done
           fi
+
+          if [ ${{ inputs.pre-release }} = true ]; then
+            options+=("--prerealse")
+          fi
+
+          hub release create "${options[@]}" -m "Release $new_tag" "$new_tag"
         fi
       shell: bash
       id: main

--- a/tag-semantic-release/action.yaml
+++ b/tag-semantic-release/action.yaml
@@ -87,7 +87,7 @@ runs:
           fi
 
           if [ ${{ inputs.pre-release }} = true ]; then
-            options+=("--prerealse")
+            options+=("--prerelease")
           fi
 
           hub release create "${options[@]}" -m "Release $new_tag" "$new_tag"


### PR DESCRIPTION
# What are the changes
- Add new input `pre-release`