### PR TITLE
Register response as output on samson webhook

### DIFF
--- a/samson-inbound-webhook/action.yaml
+++ b/samson-inbound-webhook/action.yaml
@@ -13,11 +13,15 @@ inputs:
   webhook-url:
     description: Samson generic webhook URL
     required: true
-
+outputs:
+  response:
+    description: The response from the webhook
+    value: ${{ steps.request.outputs.response }}
 runs:
   using: composite
   steps:
-    - run: |
+    - id: request
+      run: |
         # validate webhook URL
         if [[ ! "${{ inputs.webhook-url }}" =~ ^https://[^/]+/integrations/generic/[a-f0-9]{32}$ ]]; then
           echo "::error::Invalid Samson generic webhook URL format"
@@ -46,10 +50,14 @@ runs:
             '{deploy: {branch: $branchName,commit: {message: $message,sha: $sha}}}'
         )
 
-        curl \
+        response=$(curl \
           --data "$payload" \
           --header "Content-Type: application/json" \
           --request POST \
           --silent \
             "${{ inputs.webhook-url }}"
+        )
+
+        echo "::set-output name=response::$(echo $response)"
+        echo "$response"
       shell: bash

--- a/samson-inbound-webhook/action.yaml
+++ b/samson-inbound-webhook/action.yaml
@@ -17,6 +17,12 @@ outputs:
   response:
     description: The response from the webhook
     value: ${{ steps.request.outputs.response }}
+  next_tag:
+    description: Next tag, if applicable
+    value: ${{ steps.request.outputs.next_tag }}
+  previous_tag:
+    description: Previous tag, if applicable
+    value: ${{ steps.request.outputs.previous_tag }}
 runs:
   using: composite
   steps:

--- a/samson-inbound-webhook/action.yaml
+++ b/samson-inbound-webhook/action.yaml
@@ -61,7 +61,7 @@ runs:
         version=$(echo "$response" | jq .release.number)
 
         echo "$response"
-        echo "::set-output name=next_version::$(echo $version)"
-        echo "::set-output name=previous_version::$(expr $version - 1)"
+        echo "::set-output name=next_version::v$(echo $version)"
+        echo "::set-output name=previous_version::v$(expr $version - 1)"
         echo "::set-output name=response::$(echo $response)"
       shell: bash

--- a/samson-inbound-webhook/action.yaml
+++ b/samson-inbound-webhook/action.yaml
@@ -58,6 +58,10 @@ runs:
             "${{ inputs.webhook-url }}"
         )
 
-        echo "::set-output name=response::$(echo $response)"
+        version=$(echo "$response" | jq .release.number)
+
         echo "$response"
+        echo "::set-output name=next_version::$(echo $version)"
+        echo "::set-output name=previous_version::$(expr $version - 1)"
+        echo "::set-output name=response::$(echo $response)"
       shell: bash

--- a/samson-inbound-webhook/action.yaml
+++ b/samson-inbound-webhook/action.yaml
@@ -58,10 +58,13 @@ runs:
             "${{ inputs.webhook-url }}"
         )
 
-        version=$(echo "$response" | jq .release.number)
+        release_number=$(echo "$response" | jq -r '.release.number // ""')
+        if [ -n "$release_number" ]; then
+          echo "Found release in response, outputting next_tag and previous_tag"
+          echo "::set-output name=next_tag::v$(echo $release_number)"
+          echo "::set-output name=previous_tag::v$(expr $release_number - 1)"
+        fi
 
         echo "$response"
-        echo "::set-output name=next_version::v$(echo $version)"
-        echo "::set-output name=previous_version::v$(expr $version - 1)"
         echo "::set-output name=response::$(echo $response)"
       shell: bash


### PR DESCRIPTION
This webhook can be used for various things samson triggers, and it
would be nice to be able to consume the output from the webhook, so the
caller can act on that information.

```
    - name: Notify samson
      id: samson-webhook
      uses: zendesk/ga/samson-inbound-webhook@dreuss.samson-inbound-webhook-release-output
      with:
        webhook-url: https://samson.zende.sk/integrations/generic/TOKEN
    - env:
        RESPONSE: ${{ steps.samson-webhook.outputs.response }}
      run: |
        num=$(echo "$RESPONSE" | jq .release.number)
        echo YOU JUST RELEASED $num
```