### PR TITLE
Parse JUnit reports

### DIFF
--- a/dd-test-results/package-lock.json
+++ b/dd-test-results/package-lock.json
@@ -6,6 +6,9 @@
     "packages": {
         "": {
             "version": "1.0.0",
+            "dependencies": {
+                "junitxml-to-javascript": "^1.1.4"
+            },
             "devDependencies": {
                 "@types/jest": "^26.0.23",
                 "jest": "^26.6.3",
@@ -3646,6 +3649,17 @@
                 "verror": "1.10.0"
             }
         },
+        "node_modules/junitxml-to-javascript": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/junitxml-to-javascript/-/junitxml-to-javascript-1.1.4.tgz",
+            "integrity": "sha512-J5hr9WhfvZ1SqvuWtFnE0ItFDFud6EilovLDl3aOT2WNm2HfWyWgxRyK7HTHsrrgDFMe22Mfnf6yUYNPKPuFaw==",
+            "dependencies": {
+                "xml2js-parser": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=8.2.1"
+            }
+        },
         "node_modules/kind-of": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -5005,6 +5019,11 @@
                 "which": "bin/which"
             }
         },
+        "node_modules/sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        },
         "node_modules/saxes": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -6209,6 +6228,17 @@
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
             "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
+        },
+        "node_modules/xml2js-parser": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/xml2js-parser/-/xml2js-parser-1.1.1.tgz",
+            "integrity": "sha1-kNw5+dhNA2rhD0Hm52apFVBETUQ=",
+            "dependencies": {
+                "sax": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
         },
         "node_modules/xmlchars": {
             "version": "2.2.0",
@@ -9183,6 +9213,14 @@
                 "verror": "1.10.0"
             }
         },
+        "junitxml-to-javascript": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/junitxml-to-javascript/-/junitxml-to-javascript-1.1.4.tgz",
+            "integrity": "sha512-J5hr9WhfvZ1SqvuWtFnE0ItFDFud6EilovLDl3aOT2WNm2HfWyWgxRyK7HTHsrrgDFMe22Mfnf6yUYNPKPuFaw==",
+            "requires": {
+                "xml2js-parser": "^1.1.1"
+            }
+        },
         "kind-of": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -10242,6 +10280,11 @@
                 }
             }
         },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        },
         "saxes": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -11201,6 +11244,14 @@
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
             "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
+        },
+        "xml2js-parser": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/xml2js-parser/-/xml2js-parser-1.1.1.tgz",
+            "integrity": "sha1-kNw5+dhNA2rhD0Hm52apFVBETUQ=",
+            "requires": {
+                "sax": "^1.2.1"
+            }
         },
         "xmlchars": {
             "version": "2.2.0",

--- a/dd-test-results/package.json
+++ b/dd-test-results/package.json
@@ -19,5 +19,8 @@
         "@types/jest": "^26.0.23",
         "jest": "^26.6.3",
         "ts-jest": "^26.5.6"
+    },
+    "dependencies": {
+        "junitxml-to-javascript": "^1.1.4"
     }
 }

--- a/dd-test-results/src/junit-test-result-parser.ts
+++ b/dd-test-results/src/junit-test-result-parser.ts
@@ -1,3 +1,7 @@
-export function parse(testResultPath: string): string {
-  return testResultPath;
+import parser from "junitxml-to-javascript";
+
+export async function parse(testResultPath: string): Promise<TestResults> {
+  const promise = new parser().parseXMLFile(testResultPath)
+  const result = await promise
+  return { testSuites: result.testsuites }
 }

--- a/dd-test-results/src/model.ts
+++ b/dd-test-results/src/model.ts
@@ -1,0 +1,14 @@
+interface TestResults {
+    testSuites: TestSuite[];
+}
+  
+interface TestSuite {
+    name: string;
+    testCases: TestCase[];
+}
+
+interface TestCase {
+    name: string;
+    duration: number;
+    result: string;
+}

--- a/dd-test-results/tests/junit-test-result-parser.test.ts
+++ b/dd-test-results/tests/junit-test-result-parser.test.ts
@@ -1,7 +1,108 @@
+import path from "path";
 import * as parser from "../src/junit-test-result-parser";
 
+
 describe("JUnit Test Result Parser", () => {
-  it("should return input for now", () => {
-    expect(parser.parse("input")).toEqual("input");
+  
+  it("should parse Android JUnit4 test results", done => {
+    parser.parse(path.join(__dirname, "resources", "android-junit-test-results.xml"))
+      .then(r => {
+        expect(r).toEqual(
+          expect.objectContaining(
+            {
+              testSuites: expect.arrayContaining(
+                [
+                  expect.objectContaining(
+                    {
+                      name: "com.example.SampleTests",
+                      testCases: expect.arrayContaining(
+                        [
+                          expect.objectContaining(
+                            {
+                              name: "sampleTestName",
+                              duration: 1.4,
+                              result: "succeeded"
+                            }
+                          )
+                        ]
+                      )
+                    }
+                  )
+                ]
+              )
+            }
+          )
+        )
+        done();
+      })
+      .catch(e => {
+        done(e);
+      });
+  });
+
+  it("should parse iOS test results", done => {
+    parser.parse(path.join(__dirname, "resources", "ios-xctest-test-results.xml"))
+      .then(r => {
+        expect(r).toEqual(
+          expect.objectContaining(
+            {
+              testSuites: expect.arrayContaining(
+                [
+                  expect.objectContaining(
+                    {
+                      name: "MessagingIntegration_SPMAPITests.ConversationKitAPIContractTests",
+                      testCases: expect.arrayContaining(
+                        [
+                          expect.objectContaining(
+                            {
+                              name: "testItCanSetupConversationKit",
+                              duration: 0.490,
+                              result: "succeeded"
+                            }
+                          ),
+                          expect.objectContaining(
+                            {
+                              name: "testItCreatesAnonymousUser",
+                              duration: 0.515,
+                              result: "succeeded"
+                            }
+                          ),
+                          expect.objectContaining(
+                            {
+                              name: "testItGetsConversation",
+                              duration: 0,
+                              result: "failed"
+                            }
+                          )
+                        ]
+                      )
+                    }
+                  ),
+                  expect.objectContaining(
+                    {
+                      name: "MessagingIntegration_SPMAPITests.MessagingAPIContractTests",
+                      testCases: expect.arrayContaining(
+                        [
+                          expect.objectContaining(
+                            {
+                              name: "testItInitializesMessaging",
+                              duration: 1.314,
+                              result: "succeeded"
+                            }
+                          )
+                        ]
+                      )
+                    }
+                  )
+                ]
+              )
+            }
+          )
+        )
+        done();
+      })
+      .catch(e => {
+        done(e);
+      });
   });
 });

--- a/dd-test-results/tests/resources/android-junit-test-results.xml
+++ b/dd-test-results/tests/resources/android-junit-test-results.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.example.SampleTests" tests="1" skipped="0" failures="0" errors="0" timestamp="2021-05-21T08:54:02" hostname="machine" time="1.4">
+  <properties/>
+  <testcase name="sampleTestName" classname="com.example.SampleTests" time="1.4"/>
+</testsuite>

--- a/dd-test-results/tests/resources/ios-xctest-test-results.xml
+++ b/dd-test-results/tests/resources/ios-xctest-test-results.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?> 
+<testsuites name='MessagingIntegration-SPMAPITests.xctest' tests='6' failures='1' retries='2'>
+  <testsuite name='MessagingIntegration_SPMAPITests.ConversationKitAPIContractTests' tests='5' failures='1'>
+    <testcase classname='MessagingIntegration_SPMAPITests.ConversationKitAPIContractTests' name='testItCanSetupConversationKit' time='0.490'/>
+    <testcase classname='MessagingIntegration_SPMAPITests.ConversationKitAPIContractTests' name='testItCreatesAnonymousUser' time='0.515'/>
+    <testcase classname='MessagingIntegration_SPMAPITests.ConversationKitAPIContractTests' name='testItGetsConversation' retries='1'>
+      <failure message='Asynchronous wait failed: Exceeded timeout of 5 seconds, with unfulfilled expectations: &quot;Failed to get conversation&quot;.'>
+        MessagingAPIContractTests/ConversationKitAPIContractTests.swift:177
+      </failure>
+    </testcase>
+    <testcase classname='MessagingIntegration_SPMAPITests.ConversationKitAPIContractTests' name='testItRecievesMessagesToConversation' time='3.425'/>
+    <testcase classname='MessagingIntegration_SPMAPITests.ConversationKitAPIContractTests' name='testItSendsMessageToConversation' time='1.156'/>
+  </testsuite>
+  <testsuite name='MessagingIntegration_SPMAPITests.MessagingAPIContractTests' tests='1' failures='0'>
+    <testcase classname='MessagingIntegration_SPMAPITests.MessagingAPIContractTests' name='testItInitializesMessaging' time='1.314'/>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
- Parse JUnit report with a 3rd party lib
- Describe test results object with interfaces
- Add tests to verify we can in fact extract data from JUnit reports generated by Android & iOS toolchain