### PR TITLE
Add hold-merges status check action

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@
 - [slack-post-msg](slack-post-msg)
 - [sauce-connect](sauce-connect)
 - [tag-semantic-release](tag-semantic-release)
+- [hold-merges-status](hold-merges-status)

--- a/hold-merges-status/README.md
+++ b/hold-merges-status/README.md
@@ -14,8 +14,8 @@ Check with the hold-merges app to see if merging is currently allowed
 ## Inputs
 
 - `repo`: The name of the repo to check in hold-merges. Default: $GITHUB_REPOSITORY
-- `fail_on_hold_status`: Fail the check if the status from hold-merges is `hold`. Default: false
+- `fail_on_hold_status`: Fail the check if the status from hold-merges is `hold`. Set `false` to keep this informative (not recommended). Default: `true`.
 
 ## Outputs
 
-- `status`: The current merge status. Either "hold" or "allow".
+- `status`: The current merge status. Either "hold", "allow", or "error".

--- a/hold-merges-status/README.md
+++ b/hold-merges-status/README.md
@@ -1,0 +1,21 @@
+# Hold-merges status check
+
+Check with the hold-merges app to see if merging is currently allowed
+
+## Usage
+
+```yaml
+- name: Hold-merges Status
+  uses: zendesk/ga/hold-merges-status@v2
+  with:
+    repo: GITHUB_REPOSITORY
+```
+
+## Inputs
+
+- `repo`: The name of the repo to check in hold-merges. Default: $GITHUB_REPOSITORY
+- `fail_on_hold_status`: Fail the check if the status from hold-merges is `hold`. Default: false
+
+## Outputs
+
+- `status`: The current merge status. Either "hold" or "allow".

--- a/hold-merges-status/action.js
+++ b/hold-merges-status/action.js
@@ -1,0 +1,32 @@
+const core = require('@actions/core')
+const httpm = require('@actions/http-client')
+const process = require('process')
+
+const HOLD_MERGES_BASE_URL = 'http://hold-merges.internaltools-staging-use1.zende.sk'
+
+async function fetchStatus() {
+  const repo = core.getInput('repo') || process.env['GITHUB_REPOSITORY']
+  const client = new httpm.HttpClient('hold-merges-action')
+  const response = await client.get(`${HOLD_MERGES_BASE_URL}/status/${repo}`)
+  const body = await response.readBody()
+  const json = JSON.parse(body)
+
+  return json.status
+}
+
+async function run() {
+  const status = await fetchStatus()
+
+  core.info(`Hold-merges status: ${status}`)
+  core.setOutput('status', status)
+
+  if (core.getInput('fail_on_hold_status')) {
+    core.setFailed('Hold status detected. Failing check.')
+  }
+}
+
+try {
+  run()
+} catch (error) {
+  core.setFailed(`Action failed with error ${error}`)
+}

--- a/hold-merges-status/action.js
+++ b/hold-merges-status/action.js
@@ -6,7 +6,7 @@ const HOLD_MERGES_BASE_URL = 'http://hold-merges.internaltools-staging-use1.zend
 
 async function fetchStatus() {
   const repo = core.getInput('repo') || process.env['GITHUB_REPOSITORY']
-  const client = new httpm.HttpClient('hold-merges-action')
+  const client = new httpm.HttpClient('hold-merges-action', undefined, { socketTimeout: 30000 });
   const response = await client.get(`${HOLD_MERGES_BASE_URL}/status/${repo}`)
   const body = await response.readBody()
   const json = JSON.parse(body)
@@ -20,7 +20,7 @@ async function run() {
   core.info(`Hold-merges status: ${status}`)
   core.setOutput('status', status)
 
-  if (core.getInput('fail_on_hold_status')) {
+  if (status == 'hold' && core.getInput('fail_on_hold_status') != 'false') {
     core.setFailed('Hold status detected. Failing check.')
   }
 }
@@ -28,5 +28,6 @@ async function run() {
 try {
   run()
 } catch (error) {
+  core.setOutput('status', 'error')
   core.setFailed(`Action failed with error ${error}`)
 }

--- a/hold-merges-status/action.yml
+++ b/hold-merges-status/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
   fail_on_hold_status:
     description: >
-      Fail the check if the status from hold-merges is `hold`. Default: false
+      Fail the check if the status from hold-merges is `hold`. Set `false` to keep this informative (not recommended). Default: `true`.
     required: false
 
 outputs:

--- a/hold-merges-status/action.yml
+++ b/hold-merges-status/action.yml
@@ -21,4 +21,4 @@ inputs:
 
 outputs:
   status:
-    description: The current merge status. Either "hold", "allow", "error".
+    description: The current merge status. Either "hold", "allow", or "error".

--- a/hold-merges-status/action.yml
+++ b/hold-merges-status/action.yml
@@ -1,0 +1,24 @@
+name: Hold Merges
+description: Check with the hold-merges app to see if merging is currently allowed
+author: Craig Day
+branding:
+  color: blue
+  icon: git-merge
+
+runs:
+  using: node12
+  main: action.js
+
+inputs:
+  repo:
+    description: >
+      The name of the repo to check in hold-merges. Default: $GITHUB_REPOSITORY
+    required: false
+  fail_on_hold_status:
+    description: >
+      Fail the check if the status from hold-merges is `hold`. Default: false
+    required: false
+
+outputs:
+  status:
+    description: The current merge status. Either "hold" or "allow".

--- a/hold-merges-status/action.yml
+++ b/hold-merges-status/action.yml
@@ -21,4 +21,4 @@ inputs:
 
 outputs:
   status:
-    description: The current merge status. Either "hold" or "allow".
+    description: The current merge status. Either "hold", "allow", "error".

--- a/hold-merges-status/package-lock.json
+++ b/hold-merges-status/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "hold-merges",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@actions/core": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+    },
+    "@actions/http-client": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.9.tgz",
+      "integrity": "sha512-0O4SsJ7q+MK0ycvXPl2e6bMXV7dxAXOGjrXS1eTF9s2S401Tp6c/P3c3Joz04QefC1J6Gt942Wl2jbm3f4mLcg==",
+      "requires": {
+        "tunnel": "0.0.6"
+      }
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    }
+  }
+}

--- a/hold-merges-status/package.json
+++ b/hold-merges-status/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "hold-merges",
+  "version": "0.1.0",
+  "description": "Check with the hold-merges app to see if merging is currently allowed",
+  "main": "action.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zendesk/hold-merges.git"
+  },
+  "author": "Craig Day",
+  "license": "MIT",
+  "private": true,
+  "bugs": {
+    "url": "https://github.com/zendesk/hold-merges/issues"
+  },
+  "homepage": "https://github.com/zendesk/hold-merges#readme",
+  "dependencies": {
+    "@actions/core": "^1.2.6",
+    "@actions/http-client": "^1.0.9"
+  }
+}


### PR DESCRIPTION
This adds an action which returns the status of the https://github.com/zendesk/hold-merges app for a given repo, optionally failing if `hold` conditions are met. Based on work in https://github.com/zendesk/hold-merges/pull/66, which adds the `/status/:repo` endpoint this action uses (and which originally implemented the action).