### PR TITLE
Tags via YML

### DIFF
--- a/dd-test-results/README.md
+++ b/dd-test-results/README.md
@@ -10,6 +10,8 @@ GitHub Action to report test results to Datadog.
   with:
     dd-api-key: ${{ secrets.DATADOG_API_KEY }}
     dd-metric-name: zendesk.tests
+    dd-tags: |
+     - "key:value"
     dd-host: ${{ github.repository_owner }}
     test-framework: junit|nunit|mstest
     test-report-file: build/test/report.xml
@@ -20,6 +22,7 @@ GitHub Action to report test results to Datadog.
 
 - `dd-api-key`: Datadog API key (required)
 - `dd-metric-name`: Datadog metric name
+- `dd-tags`: Datadog metric tags. Accepts multiline input where each line consists of key-value entry separated by colon (`:`).
 - `dd-host`: Datadog host name
 - `test-framework`: Type of test framework (junit | nunit | mstest)
 - `test-report-file`: Path to the test report file. Supports [glob pattern](https://en.wikipedia.org/wiki/Glob_(programming))
@@ -36,6 +39,8 @@ steps:
     with:
       dd-api-key: ${{ secrets.DATADOG_API_KEY }}
       dd-metric-name: zendesk.tests
+      dd-tags: |
+        - "job_name:${{ github.name }}"
       dd-host: ${{ github.repository_owner }}
       test-framework: junit
       test-report-file: ./**/build/outputs/androidTest-results/connected/app.xml
@@ -48,13 +53,20 @@ By default, each test result will include the following Datadog metric tags:
 - `success`: Either `true` or `false`. Extracted from the provided test report
 - `test_case`: Name of the test case extracted from the provided test report.
 
-To decorate test results with additional tags, provide a JSON file with the following structure as the input to the action:
+The action enables you to specify additional tags:
+- directly in the YML or 
+- in a supplementary JSON file.
+
+Tags provided in the YML are applied to all test cases in all test suites.
+
+Tags provided in the JSON file are applied to a specific test suites and cases.
+
+### JSON File
+
+To decorate test results with additional tags via JSON file, ensure the content adheres to the following structure:
 
 ```json
 {
-  "tags": { 
-    "team": "Team A"
-  },
   "suites": [
     {
       "name": "test_suite_name",
@@ -75,15 +87,12 @@ To decorate test results with additional tags, provide a JSON file with the foll
 }
 ```
 
-The action will then traverse the file, extracting and aggregating tags for each test case.
-
-You can specify tags at three levels:
-- globally at the root
+You can specify tags at two levels:
 - within a test suite
 - within a test case
-
-Tags specified at the root are applied to all test cases in all test suites.
 
 Tags specified for a particular test suite are applied only to test cases within that suite.
 
 Tags specified for a particular test cases are applied only to that test case.
+
+**NOTE**: All the tags specified in the JSON will be overriden by tags in YML given the same tag key.

--- a/dd-test-results/action.yml
+++ b/dd-test-results/action.yml
@@ -9,6 +9,9 @@ inputs:
   dd-metric-name:
     description: 'Datadog metric name'
     required: true
+  dd-tags:
+    description: Datadog metric tags
+    required: false
   dd-host:
     description: 'Datadog host name'
     required: true

--- a/dd-test-results/dist/index.js
+++ b/dd-test-results/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 9191:
+/***/ 2529:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -36,8 +36,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DataDogClient = void 0;
-const core = __importStar(__nccwpck_require__(6024));
-const http = __importStar(__nccwpck_require__(9628));
+const core = __importStar(__nccwpck_require__(9869));
+const http = __importStar(__nccwpck_require__(2849));
 class DataDogClient {
     constructor(apiKey, baseURL) {
         this._client = new http.HttpClient('dd-http-client', [], {
@@ -115,7 +115,7 @@ exports.DataDogClient = DataDogClient;
 
 /***/ }),
 
-/***/ 19:
+/***/ 3781:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -134,7 +134,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parse = void 0;
-const junitxml_to_javascript_1 = __importDefault(__nccwpck_require__(4014));
+const junitxml_to_javascript_1 = __importDefault(__nccwpck_require__(5268));
 function parse(testResultPath) {
     return __awaiter(this, void 0, void 0, function* () {
         const promise = new junitxml_to_javascript_1.default().parseXMLFile(testResultPath);
@@ -147,7 +147,7 @@ exports.parse = parse;
 
 /***/ }),
 
-/***/ 1739:
+/***/ 7209:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -184,10 +184,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__nccwpck_require__(6024));
-const client_1 = __nccwpck_require__(9191);
-const run_1 = __nccwpck_require__(8141);
-const glob_1 = __importDefault(__nccwpck_require__(2723));
+const core = __importStar(__nccwpck_require__(9869));
+const client_1 = __nccwpck_require__(2529);
+const run_1 = __nccwpck_require__(1018);
+const glob_1 = __importDefault(__nccwpck_require__(4370));
 const fs_1 = __nccwpck_require__(5747);
 const util_1 = __nccwpck_require__(1669);
 const stats = util_1.promisify(fs_1.stat);
@@ -208,6 +208,7 @@ function findTestReports(testReportFile) {
 }
 run_1.run(new client_1.DataDogClient(core.getInput('dd-api-key', { required: true })), {
     metricName: core.getInput('dd-metric-name', { required: true }),
+    tags: core.getMultilineInput('dd-tags', { required: false }),
     host: core.getInput('dd-host', { required: true }),
     testFramework: core.getInput('test-framework', { required: true }),
     testReportFiles: findTestReports(core.getInput('test-report-file', { required: true })),
@@ -217,7 +218,7 @@ run_1.run(new client_1.DataDogClient(core.getInput('dd-api-key', { required: tru
 
 /***/ }),
 
-/***/ 6754:
+/***/ 1705:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -260,7 +261,7 @@ function includeRequiredTags(taggedTestCase) {
 
 /***/ }),
 
-/***/ 8645:
+/***/ 3801:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -279,8 +280,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parse = void 0;
-const xml2js_1 = __importDefault(__nccwpck_require__(9253));
-const xml2js_xpath_1 = __importDefault(__nccwpck_require__(381));
+const xml2js_1 = __importDefault(__nccwpck_require__(3356));
+const xml2js_xpath_1 = __importDefault(__nccwpck_require__(1762));
 const fs_1 = __importDefault(__nccwpck_require__(5747));
 function parse(testResultPath) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -333,7 +334,7 @@ function convertDurationToSeconds(testCaseDuration) {
 
 /***/ }),
 
-/***/ 2782:
+/***/ 4739:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -352,8 +353,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parse = void 0;
-const xml2js_1 = __importDefault(__nccwpck_require__(9253));
-const xml2js_xpath_1 = __importDefault(__nccwpck_require__(381));
+const xml2js_1 = __importDefault(__nccwpck_require__(3356));
+const xml2js_xpath_1 = __importDefault(__nccwpck_require__(1762));
 const fs_1 = __importDefault(__nccwpck_require__(5747));
 function parse(testResultPath) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -396,7 +397,7 @@ function appendToTestSuite(testCaseElement, testSuites) {
 
 /***/ }),
 
-/***/ 8141:
+/***/ 1018:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -431,11 +432,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.run = void 0;
-const junitTestResultParser = __importStar(__nccwpck_require__(19));
-const nunitTestResultParser = __importStar(__nccwpck_require__(2782));
-const mstestTestResultParser = __importStar(__nccwpck_require__(8645));
-const tagging_1 = __nccwpck_require__(7469);
-const metrics_1 = __nccwpck_require__(6754);
+const junitTestResultParser = __importStar(__nccwpck_require__(3781));
+const nunitTestResultParser = __importStar(__nccwpck_require__(4739));
+const mstestTestResultParser = __importStar(__nccwpck_require__(3801));
+const tagging_1 = __nccwpck_require__(5387);
+const metrics_1 = __nccwpck_require__(1705);
 function parse(testFramework, testReportFile) {
     switch (testFramework) {
         case 'junit':
@@ -453,7 +454,7 @@ function run(client, inputs) {
         let allMetrics = [];
         for (const testReportFile of yield inputs.testReportFiles) {
             const testResults = parse(inputs.testFramework, testReportFile);
-            const taggedTestCases = tagging_1.tagTestResults(testResults, inputs.testTagsFile);
+            const taggedTestCases = tagging_1.tagTestResults(inputs.tags, testResults, inputs.testTagsFile);
             const metrics = metrics_1.buildAllMetrics(taggedTestCases, inputs.metricName, inputs.host);
             allMetrics = [...allMetrics, ...metrics];
         }
@@ -465,7 +466,7 @@ exports.run = run;
 
 /***/ }),
 
-/***/ 7469:
+/***/ 5387:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -475,15 +476,26 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tagTestResults = exports.loadTagsFromFile = void 0;
-function tagTestCases(testResults, testResultsTags) {
+function tagTestCases(tags, testResults, testResultsTags) {
     return testResults.testSuites
-        .map(testSuite => testSuite.testCases.map(testCase => tagTestCase(testSuite, testCase, testResultsTags)))
+        .map(testSuite => testSuite.testCases.map(testCase => tagTestCase(tags, testSuite, testCase, testResultsTags)))
         .reduce((total, current) => [...total, ...current]);
 }
-function tagTestCase(testSuite, testCase, testResultsTags) {
+function tagTestCase(tags, testSuite, testCase, testResultsTags) {
     const testSuiteTags = testResultsTags.suites.find(testSuiteTags => testSuiteTags.name === testSuite.name);
     const testCaseTags = testSuiteTags === null || testSuiteTags === void 0 ? void 0 : testSuiteTags.cases.find(testCaseTags => testCaseTags.name === testCase.name);
-    return Object.assign(Object.assign({}, testCase), { tags: Object.assign(Object.assign(Object.assign({}, testResultsTags.tags), testSuiteTags === null || testSuiteTags === void 0 ? void 0 : testSuiteTags.tags), testCaseTags === null || testCaseTags === void 0 ? void 0 : testCaseTags.tags) });
+    return Object.assign(Object.assign({}, testCase), { tags: Object.assign(Object.assign(Object.assign({}, testSuiteTags === null || testSuiteTags === void 0 ? void 0 : testSuiteTags.tags), testCaseTags === null || testCaseTags === void 0 ? void 0 : testCaseTags.tags), parseTags(tags)) });
+}
+function parseTags(rawTags) {
+    const r = {};
+    rawTags
+        .filter(rawTag => rawTag.includes(':'))
+        .forEach(rawTag => {
+        const key = rawTag.split(':')[0];
+        const value = rawTag.substring(key.length + 1);
+        r[key] = value;
+    });
+    return r;
 }
 const fs_1 = __importDefault(__nccwpck_require__(5747));
 function loadTagsFromFile(filePath) {
@@ -492,15 +504,15 @@ function loadTagsFromFile(filePath) {
     return json;
 }
 exports.loadTagsFromFile = loadTagsFromFile;
-function tagTestResults(testResults, tagsFile) {
-    return tagTestCases(testResults, loadTagsFromFile(tagsFile));
+function tagTestResults(tags, testResults, tagsFile) {
+    return tagTestCases(tags, testResults, loadTagsFromFile(tagsFile));
 }
 exports.tagTestResults = tagTestResults;
 
 
 /***/ }),
 
-/***/ 5350:
+/***/ 562:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -527,7 +539,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
 const os = __importStar(__nccwpck_require__(2087));
-const utils_1 = __nccwpck_require__(7369);
+const utils_1 = __nccwpck_require__(9525);
 /**
  * Commands
  *
@@ -599,7 +611,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 6024:
+/***/ 9869:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -633,10 +645,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(5350);
-const file_command_1 = __nccwpck_require__(8466);
-const utils_1 = __nccwpck_require__(7369);
+exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
+const command_1 = __nccwpck_require__(562);
+const file_command_1 = __nccwpck_require__(6002);
+const utils_1 = __nccwpck_require__(9525);
 const os = __importStar(__nccwpck_require__(2087));
 const path = __importStar(__nccwpck_require__(5622));
 /**
@@ -719,6 +731,21 @@ function getInput(name, options) {
     return val.trim();
 }
 exports.getInput = getInput;
+/**
+ * Gets the values of an multiline input.  Each value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string[]
+ *
+ */
+function getMultilineInput(name, options) {
+    const inputs = getInput(name, options)
+        .split('\n')
+        .filter(x => x !== '');
+    return inputs;
+}
+exports.getMultilineInput = getMultilineInput;
 /**
  * Gets the input value of the boolean type in the YAML 1.2 "core schema" specification.
  * Support boolean input list: `true | True | TRUE | false | False | FALSE` .
@@ -885,7 +912,7 @@ exports.getState = getState;
 
 /***/ }),
 
-/***/ 8466:
+/***/ 6002:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -916,7 +943,7 @@ exports.issueCommand = void 0;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(5747));
 const os = __importStar(__nccwpck_require__(2087));
-const utils_1 = __nccwpck_require__(7369);
+const utils_1 = __nccwpck_require__(9525);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -934,7 +961,7 @@ exports.issueCommand = issueCommand;
 
 /***/ }),
 
-/***/ 7369:
+/***/ 9525:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -961,7 +988,7 @@ exports.toCommandValue = toCommandValue;
 
 /***/ }),
 
-/***/ 2723:
+/***/ 4370:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -977,8 +1004,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.hashFiles = exports.create = void 0;
-const internal_globber_1 = __nccwpck_require__(4581);
-const internal_hash_files_1 = __nccwpck_require__(7907);
+const internal_globber_1 = __nccwpck_require__(4448);
+const internal_hash_files_1 = __nccwpck_require__(5560);
 /**
  * Constructs a globber
  *
@@ -1012,7 +1039,7 @@ exports.hashFiles = hashFiles;
 
 /***/ }),
 
-/***/ 9897:
+/***/ 9316:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1038,7 +1065,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOptions = void 0;
-const core = __importStar(__nccwpck_require__(6024));
+const core = __importStar(__nccwpck_require__(9869));
 /**
  * Returns a copy with defaults filled in.
  */
@@ -1074,7 +1101,7 @@ exports.getOptions = getOptions;
 
 /***/ }),
 
-/***/ 4581:
+/***/ 4448:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1128,14 +1155,14 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DefaultGlobber = void 0;
-const core = __importStar(__nccwpck_require__(6024));
+const core = __importStar(__nccwpck_require__(9869));
 const fs = __importStar(__nccwpck_require__(5747));
-const globOptionsHelper = __importStar(__nccwpck_require__(9897));
+const globOptionsHelper = __importStar(__nccwpck_require__(9316));
 const path = __importStar(__nccwpck_require__(5622));
-const patternHelper = __importStar(__nccwpck_require__(7676));
-const internal_match_kind_1 = __nccwpck_require__(7119);
-const internal_pattern_1 = __nccwpck_require__(8339);
-const internal_search_state_1 = __nccwpck_require__(7001);
+const patternHelper = __importStar(__nccwpck_require__(3300));
+const internal_match_kind_1 = __nccwpck_require__(1204);
+const internal_pattern_1 = __nccwpck_require__(5618);
+const internal_search_state_1 = __nccwpck_require__(4576);
 const IS_WINDOWS = process.platform === 'win32';
 class DefaultGlobber {
     constructor(options) {
@@ -1316,7 +1343,7 @@ exports.DefaultGlobber = DefaultGlobber;
 
 /***/ }),
 
-/***/ 7907:
+/***/ 5560:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1359,7 +1386,7 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.hashFiles = void 0;
 const crypto = __importStar(__nccwpck_require__(6417));
-const core = __importStar(__nccwpck_require__(6024));
+const core = __importStar(__nccwpck_require__(9869));
 const fs = __importStar(__nccwpck_require__(5747));
 const stream = __importStar(__nccwpck_require__(2413));
 const util = __importStar(__nccwpck_require__(1669));
@@ -1417,7 +1444,7 @@ exports.hashFiles = hashFiles;
 
 /***/ }),
 
-/***/ 7119:
+/***/ 1204:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1442,7 +1469,7 @@ var MatchKind;
 
 /***/ }),
 
-/***/ 3011:
+/***/ 6517:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1647,7 +1674,7 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 
 /***/ }),
 
-/***/ 2288:
+/***/ 5640:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1677,7 +1704,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Path = void 0;
 const path = __importStar(__nccwpck_require__(5622));
-const pathHelper = __importStar(__nccwpck_require__(3011));
+const pathHelper = __importStar(__nccwpck_require__(6517));
 const assert_1 = __importDefault(__nccwpck_require__(2357));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -1767,7 +1794,7 @@ exports.Path = Path;
 
 /***/ }),
 
-/***/ 7676:
+/***/ 3300:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1793,8 +1820,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.partialMatch = exports.match = exports.getSearchPaths = void 0;
-const pathHelper = __importStar(__nccwpck_require__(3011));
-const internal_match_kind_1 = __nccwpck_require__(7119);
+const pathHelper = __importStar(__nccwpck_require__(6517));
+const internal_match_kind_1 = __nccwpck_require__(1204);
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Given an array of patterns, returns an array of paths to search.
@@ -1868,7 +1895,7 @@ exports.partialMatch = partialMatch;
 
 /***/ }),
 
-/***/ 8339:
+/***/ 5618:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1899,11 +1926,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Pattern = void 0;
 const os = __importStar(__nccwpck_require__(2087));
 const path = __importStar(__nccwpck_require__(5622));
-const pathHelper = __importStar(__nccwpck_require__(3011));
+const pathHelper = __importStar(__nccwpck_require__(6517));
 const assert_1 = __importDefault(__nccwpck_require__(2357));
-const minimatch_1 = __nccwpck_require__(2959);
-const internal_match_kind_1 = __nccwpck_require__(7119);
-const internal_path_1 = __nccwpck_require__(2288);
+const minimatch_1 = __nccwpck_require__(7958);
+const internal_match_kind_1 = __nccwpck_require__(1204);
+const internal_path_1 = __nccwpck_require__(5640);
 const IS_WINDOWS = process.platform === 'win32';
 class Pattern {
     constructor(patternOrNegate, isImplicitPattern = false, segments, homedir) {
@@ -2130,7 +2157,7 @@ exports.Pattern = Pattern;
 
 /***/ }),
 
-/***/ 7001:
+/***/ 4576:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2148,7 +2175,7 @@ exports.SearchState = SearchState;
 
 /***/ }),
 
-/***/ 9628:
+/***/ 2849:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2156,7 +2183,7 @@ exports.SearchState = SearchState;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const http = __nccwpck_require__(8605);
 const https = __nccwpck_require__(7211);
-const pm = __nccwpck_require__(6305);
+const pm = __nccwpck_require__(9311);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -2575,7 +2602,7 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __nccwpck_require__(9958);
+                tunnel = __nccwpck_require__(8541);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
@@ -2693,7 +2720,7 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 6305:
+/***/ 9311:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2758,7 +2785,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 2522:
+/***/ 4226:
 /***/ ((module) => {
 
 "use strict";
@@ -2828,11 +2855,11 @@ function range(a, b, str) {
 
 /***/ }),
 
-/***/ 308:
+/***/ 8488:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var concatMap = __nccwpck_require__(388);
-var balanced = __nccwpck_require__(2522);
+var concatMap = __nccwpck_require__(7738);
+var balanced = __nccwpck_require__(4226);
 
 module.exports = expandTop;
 
@@ -3036,7 +3063,7 @@ function expand(str, isTop) {
 
 /***/ }),
 
-/***/ 388:
+/***/ 7738:
 /***/ ((module) => {
 
 module.exports = function (xs, fn) {
@@ -3056,26 +3083,26 @@ var isArray = Array.isArray || function (xs) {
 
 /***/ }),
 
-/***/ 4014:
+/***/ 5268:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Parser = __nccwpck_require__(5071);
+const Parser = __nccwpck_require__(6327);
 
 module.exports = Parser;
 
 /***/ }),
 
-/***/ 6814:
+/***/ 5511:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const isNull = __nccwpck_require__(7264)/* .isNull */ .F;
-const TestSuite = __nccwpck_require__(1954);
+const isNull = __nccwpck_require__(7775)/* .isNull */ .F;
+const TestSuite = __nccwpck_require__(8749);
 
 /**
  * Sanitizes the object based on
@@ -3145,13 +3172,13 @@ exports.create = (resultObj, customTag, sumTestCasesDuration) => new Report(resu
 
 /***/ }),
 
-/***/ 1875:
+/***/ 257:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const isNull = __nccwpck_require__(7264)/* .isNull */ .F;
-const toFloat = __nccwpck_require__(7264)/* .toFloat */ .f;
+const isNull = __nccwpck_require__(7775)/* .isNull */ .F;
+const toFloat = __nccwpck_require__(7775)/* .toFloat */ .f;
 
 const FAILURE_KEYS = ["error", "failure", "rerunFailure"];
 const SKIP_KEYS = ["skip", "skipped"];
@@ -3190,13 +3217,13 @@ module.exports = TestCase;
 
 /***/ }),
 
-/***/ 1954:
+/***/ 8749:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const TestCase = __nccwpck_require__(1875);
-const toFloat = __nccwpck_require__(7264)/* .toFloat */ .f;
+const TestCase = __nccwpck_require__(257);
+const toFloat = __nccwpck_require__(7775)/* .toFloat */ .f;
 
 // 20171122T203218+0100
 const WEIRD_PATTERN_1 = /^([0-9]{4})([0-9]{2})([0-9]{2})T([0-9]{2})([0-9]{2})([0-9]{2})\+([0-9]{4})$/;
@@ -3252,14 +3279,14 @@ module.exports = TestSuite;
 
 /***/ }),
 
-/***/ 5071:
+/***/ 6327:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const parser = __nccwpck_require__(4749).parseStringSync;
+const parser = __nccwpck_require__(3237).parseStringSync;
 const fs = __nccwpck_require__(5747);
-const Report = __nccwpck_require__(6814);
+const Report = __nccwpck_require__(5511);
 
 /**
  * Returns new instance of Parser
@@ -3356,7 +3383,7 @@ module.exports = Parser;
 
 /***/ }),
 
-/***/ 7264:
+/***/ 7775:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3375,7 +3402,7 @@ exports.f = toFloat;
 
 /***/ }),
 
-/***/ 3380:
+/***/ 8346:
 /***/ (function(module, exports, __nccwpck_require__) {
 
 /* module decorator */ module = __nccwpck_require__.nmd(module);
@@ -20592,7 +20619,7 @@ exports.f = toFloat;
 
 /***/ }),
 
-/***/ 2959:
+/***/ 7958:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = minimatch
@@ -20604,7 +20631,7 @@ try {
 } catch (er) {}
 
 var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
-var expand = __nccwpck_require__(308)
+var expand = __nccwpck_require__(8488)
 
 var plTypes = {
   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},
@@ -21522,7 +21549,7 @@ function regExpEscape (s) {
 
 /***/ }),
 
-/***/ 6540:
+/***/ 9057:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 ;(function (sax) { // wrapper for non-node envs
@@ -23094,15 +23121,15 @@ function regExpEscape (s) {
 
 /***/ }),
 
-/***/ 9958:
+/***/ 8541:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(9306);
+module.exports = __nccwpck_require__(3003);
 
 
 /***/ }),
 
-/***/ 9306:
+/***/ 3003:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -23374,12 +23401,12 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 4749:
+/***/ 3237:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const sax = __nccwpck_require__(6540);
+const sax = __nccwpck_require__(9057);
 const events = __nccwpck_require__(8614);
 
 const DEFAULTS = {
@@ -23695,13 +23722,13 @@ module.exports.Parser = function(opts) { return new module.exports(opts); };
 
 /***/ }),
 
-/***/ 381:
+/***/ 1762:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-let _ = __nccwpck_require__(3380);
+let _ = __nccwpck_require__(8346);
 
 const ATTRKEY = '$';
 const CHARKEY = '_'; // Definition of an XML name tag: https://www.w3.org/TR/xml/#NT-Name
@@ -24044,7 +24071,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 4545:
+/***/ 2008:
 /***/ (function(__unused_webpack_module, exports) {
 
 // Generated by CoffeeScript 1.12.7
@@ -24063,7 +24090,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 9112:
+/***/ 494:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -24072,9 +24099,9 @@ module.exports.jsonText = jsonText;
   var builder, defaults, escapeCDATA, requiresCDATA, wrapCDATA,
     hasProp = {}.hasOwnProperty;
 
-  builder = __nccwpck_require__(4312);
+  builder = __nccwpck_require__(4730);
 
-  defaults = __nccwpck_require__(7246).defaults;
+  defaults = __nccwpck_require__(8978).defaults;
 
   requiresCDATA = function(entry) {
     return typeof entry === "string" && (entry.indexOf('&') >= 0 || entry.indexOf('>') >= 0 || entry.indexOf('<') >= 0);
@@ -24197,7 +24224,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 7246:
+/***/ 8978:
 /***/ (function(__unused_webpack_module, exports) {
 
 // Generated by CoffeeScript 1.12.7
@@ -24276,7 +24303,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 5721:
+/***/ 9168:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -24287,17 +24314,17 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  sax = __nccwpck_require__(6540);
+  sax = __nccwpck_require__(9057);
 
   events = __nccwpck_require__(8614);
 
-  bom = __nccwpck_require__(4545);
+  bom = __nccwpck_require__(2008);
 
-  processors = __nccwpck_require__(6434);
+  processors = __nccwpck_require__(8382);
 
   setImmediate = __nccwpck_require__(8213).setImmediate;
 
-  defaults = __nccwpck_require__(7246).defaults;
+  defaults = __nccwpck_require__(8978).defaults;
 
   isEmpty = function(thing) {
     return typeof thing === "object" && (thing != null) && Object.keys(thing).length === 0;
@@ -24664,7 +24691,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 6434:
+/***/ 8382:
 /***/ (function(__unused_webpack_module, exports) {
 
 // Generated by CoffeeScript 1.12.7
@@ -24705,7 +24732,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 9253:
+/***/ 3356:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -24715,13 +24742,13 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  defaults = __nccwpck_require__(7246);
+  defaults = __nccwpck_require__(8978);
 
-  builder = __nccwpck_require__(9112);
+  builder = __nccwpck_require__(494);
 
-  parser = __nccwpck_require__(5721);
+  parser = __nccwpck_require__(9168);
 
-  processors = __nccwpck_require__(6434);
+  processors = __nccwpck_require__(8382);
 
   exports.defaults = defaults.defaults;
 
@@ -24751,7 +24778,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 2273:
+/***/ 9511:
 /***/ (function(module) {
 
 // Generated by CoffeeScript 1.12.7
@@ -24770,7 +24797,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 7777:
+/***/ 4601:
 /***/ (function(module) {
 
 // Generated by CoffeeScript 1.12.7
@@ -24800,7 +24827,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 4259:
+/***/ 1488:
 /***/ (function(module) {
 
 // Generated by CoffeeScript 1.12.7
@@ -24890,7 +24917,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 9461:
+/***/ 4260:
 /***/ (function(module) {
 
 // Generated by CoffeeScript 1.12.7
@@ -24907,16 +24934,16 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 8977:
+/***/ 16:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
 (function() {
   var NodeType, XMLAttribute, XMLNode;
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  XMLNode = __nccwpck_require__(352);
+  XMLNode = __nccwpck_require__(8918);
 
   module.exports = XMLAttribute = (function() {
     function XMLAttribute(parent, name, value) {
@@ -25022,7 +25049,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 5830:
+/***/ 1232:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25031,9 +25058,9 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  XMLCharacterData = __nccwpck_require__(7269);
+  XMLCharacterData = __nccwpck_require__(8557);
 
   module.exports = XMLCData = (function(superClass) {
     extend(XMLCData, superClass);
@@ -25065,7 +25092,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 7269:
+/***/ 8557:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25074,7 +25101,7 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  XMLNode = __nccwpck_require__(352);
+  XMLNode = __nccwpck_require__(8918);
 
   module.exports = XMLCharacterData = (function(superClass) {
     extend(XMLCharacterData, superClass);
@@ -25151,7 +25178,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 4167:
+/***/ 1187:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25160,9 +25187,9 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  XMLCharacterData = __nccwpck_require__(7269);
+  XMLCharacterData = __nccwpck_require__(8557);
 
   module.exports = XMLComment = (function(superClass) {
     extend(XMLComment, superClass);
@@ -25194,16 +25221,16 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 4553:
+/***/ 8277:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
 (function() {
   var XMLDOMConfiguration, XMLDOMErrorHandler, XMLDOMStringList;
 
-  XMLDOMErrorHandler = __nccwpck_require__(7063);
+  XMLDOMErrorHandler = __nccwpck_require__(7770);
 
-  XMLDOMStringList = __nccwpck_require__(3424);
+  XMLDOMStringList = __nccwpck_require__(4437);
 
   module.exports = XMLDOMConfiguration = (function() {
     function XMLDOMConfiguration() {
@@ -25265,7 +25292,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 7063:
+/***/ 7770:
 /***/ (function(module) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25288,7 +25315,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 424:
+/***/ 7443:
 /***/ (function(module) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25327,7 +25354,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 3424:
+/***/ 4437:
 /***/ (function(module) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25362,7 +25389,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 720:
+/***/ 4946:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25371,9 +25398,9 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  XMLNode = __nccwpck_require__(352);
+  XMLNode = __nccwpck_require__(8918);
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
   module.exports = XMLDTDAttList = (function(superClass) {
     extend(XMLDTDAttList, superClass);
@@ -25424,7 +25451,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 5965:
+/***/ 3168:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25433,9 +25460,9 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  XMLNode = __nccwpck_require__(352);
+  XMLNode = __nccwpck_require__(8918);
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
   module.exports = XMLDTDElement = (function(superClass) {
     extend(XMLDTDElement, superClass);
@@ -25469,7 +25496,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 3645:
+/***/ 9691:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25478,11 +25505,11 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  isObject = __nccwpck_require__(4259).isObject;
+  isObject = __nccwpck_require__(1488).isObject;
 
-  XMLNode = __nccwpck_require__(352);
+  XMLNode = __nccwpck_require__(8918);
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
   module.exports = XMLDTDEntity = (function(superClass) {
     extend(XMLDTDEntity, superClass);
@@ -25573,7 +25600,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 7341:
+/***/ 7818:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25582,9 +25609,9 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  XMLNode = __nccwpck_require__(352);
+  XMLNode = __nccwpck_require__(8918);
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
   module.exports = XMLDTDNotation = (function(superClass) {
     extend(XMLDTDNotation, superClass);
@@ -25632,7 +25659,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 3832:
+/***/ 3727:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25641,11 +25668,11 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  isObject = __nccwpck_require__(4259).isObject;
+  isObject = __nccwpck_require__(1488).isObject;
 
-  XMLNode = __nccwpck_require__(352);
+  XMLNode = __nccwpck_require__(8918);
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
   module.exports = XMLDeclaration = (function(superClass) {
     extend(XMLDeclaration, superClass);
@@ -25682,7 +25709,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 2371:
+/***/ 4923:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25691,21 +25718,21 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  isObject = __nccwpck_require__(4259).isObject;
+  isObject = __nccwpck_require__(1488).isObject;
 
-  XMLNode = __nccwpck_require__(352);
+  XMLNode = __nccwpck_require__(8918);
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  XMLDTDAttList = __nccwpck_require__(720);
+  XMLDTDAttList = __nccwpck_require__(4946);
 
-  XMLDTDEntity = __nccwpck_require__(3645);
+  XMLDTDEntity = __nccwpck_require__(9691);
 
-  XMLDTDElement = __nccwpck_require__(5965);
+  XMLDTDElement = __nccwpck_require__(3168);
 
-  XMLDTDNotation = __nccwpck_require__(7341);
+  XMLDTDNotation = __nccwpck_require__(7818);
 
-  XMLNamedNodeMap = __nccwpck_require__(4533);
+  XMLNamedNodeMap = __nccwpck_require__(597);
 
   module.exports = XMLDocType = (function(superClass) {
     extend(XMLDocType, superClass);
@@ -25875,7 +25902,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 8051:
+/***/ 6791:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -25884,19 +25911,19 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  isPlainObject = __nccwpck_require__(4259).isPlainObject;
+  isPlainObject = __nccwpck_require__(1488).isPlainObject;
 
-  XMLDOMImplementation = __nccwpck_require__(424);
+  XMLDOMImplementation = __nccwpck_require__(7443);
 
-  XMLDOMConfiguration = __nccwpck_require__(4553);
+  XMLDOMConfiguration = __nccwpck_require__(8277);
 
-  XMLNode = __nccwpck_require__(352);
+  XMLNode = __nccwpck_require__(8918);
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  XMLStringifier = __nccwpck_require__(2652);
+  XMLStringifier = __nccwpck_require__(2033);
 
-  XMLStringWriter = __nccwpck_require__(1393);
+  XMLStringWriter = __nccwpck_require__(8433);
 
   module.exports = XMLDocument = (function(superClass) {
     extend(XMLDocument, superClass);
@@ -26124,7 +26151,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 8189:
+/***/ 718:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -26132,43 +26159,43 @@ module.exports.jsonText = jsonText;
   var NodeType, WriterState, XMLAttribute, XMLCData, XMLComment, XMLDTDAttList, XMLDTDElement, XMLDTDEntity, XMLDTDNotation, XMLDeclaration, XMLDocType, XMLDocument, XMLDocumentCB, XMLElement, XMLProcessingInstruction, XMLRaw, XMLStringWriter, XMLStringifier, XMLText, getValue, isFunction, isObject, isPlainObject, ref,
     hasProp = {}.hasOwnProperty;
 
-  ref = __nccwpck_require__(4259), isObject = ref.isObject, isFunction = ref.isFunction, isPlainObject = ref.isPlainObject, getValue = ref.getValue;
+  ref = __nccwpck_require__(1488), isObject = ref.isObject, isFunction = ref.isFunction, isPlainObject = ref.isPlainObject, getValue = ref.getValue;
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  XMLDocument = __nccwpck_require__(8051);
+  XMLDocument = __nccwpck_require__(6791);
 
-  XMLElement = __nccwpck_require__(2262);
+  XMLElement = __nccwpck_require__(299);
 
-  XMLCData = __nccwpck_require__(5830);
+  XMLCData = __nccwpck_require__(1232);
 
-  XMLComment = __nccwpck_require__(4167);
+  XMLComment = __nccwpck_require__(1187);
 
-  XMLRaw = __nccwpck_require__(7432);
+  XMLRaw = __nccwpck_require__(2321);
 
-  XMLText = __nccwpck_require__(4982);
+  XMLText = __nccwpck_require__(5630);
 
-  XMLProcessingInstruction = __nccwpck_require__(8951);
+  XMLProcessingInstruction = __nccwpck_require__(6523);
 
-  XMLDeclaration = __nccwpck_require__(3832);
+  XMLDeclaration = __nccwpck_require__(3727);
 
-  XMLDocType = __nccwpck_require__(2371);
+  XMLDocType = __nccwpck_require__(4923);
 
-  XMLDTDAttList = __nccwpck_require__(720);
+  XMLDTDAttList = __nccwpck_require__(4946);
 
-  XMLDTDEntity = __nccwpck_require__(3645);
+  XMLDTDEntity = __nccwpck_require__(9691);
 
-  XMLDTDElement = __nccwpck_require__(5965);
+  XMLDTDElement = __nccwpck_require__(3168);
 
-  XMLDTDNotation = __nccwpck_require__(7341);
+  XMLDTDNotation = __nccwpck_require__(7818);
 
-  XMLAttribute = __nccwpck_require__(8977);
+  XMLAttribute = __nccwpck_require__(16);
 
-  XMLStringifier = __nccwpck_require__(2652);
+  XMLStringifier = __nccwpck_require__(2033);
 
-  XMLStringWriter = __nccwpck_require__(1393);
+  XMLStringWriter = __nccwpck_require__(8433);
 
-  WriterState = __nccwpck_require__(9461);
+  WriterState = __nccwpck_require__(4260);
 
   module.exports = XMLDocumentCB = (function() {
     function XMLDocumentCB(options, onData, onEnd) {
@@ -26659,7 +26686,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 9230:
+/***/ 5907:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -26668,9 +26695,9 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  XMLNode = __nccwpck_require__(352);
+  XMLNode = __nccwpck_require__(8918);
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
   module.exports = XMLDummy = (function(superClass) {
     extend(XMLDummy, superClass);
@@ -26697,7 +26724,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 2262:
+/***/ 299:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -26706,15 +26733,15 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  ref = __nccwpck_require__(4259), isObject = ref.isObject, isFunction = ref.isFunction, getValue = ref.getValue;
+  ref = __nccwpck_require__(1488), isObject = ref.isObject, isFunction = ref.isFunction, getValue = ref.getValue;
 
-  XMLNode = __nccwpck_require__(352);
+  XMLNode = __nccwpck_require__(8918);
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  XMLAttribute = __nccwpck_require__(8977);
+  XMLAttribute = __nccwpck_require__(16);
 
-  XMLNamedNodeMap = __nccwpck_require__(4533);
+  XMLNamedNodeMap = __nccwpck_require__(597);
 
   module.exports = XMLElement = (function(superClass) {
     extend(XMLElement, superClass);
@@ -27002,7 +27029,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 4533:
+/***/ 597:
 /***/ (function(module) {
 
 // Generated by CoffeeScript 1.12.7
@@ -27067,7 +27094,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 352:
+/***/ 8918:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -27075,7 +27102,7 @@ module.exports.jsonText = jsonText;
   var DocumentPosition, NodeType, XMLCData, XMLComment, XMLDeclaration, XMLDocType, XMLDummy, XMLElement, XMLNamedNodeMap, XMLNode, XMLNodeList, XMLProcessingInstruction, XMLRaw, XMLText, getValue, isEmpty, isFunction, isObject, ref1,
     hasProp = {}.hasOwnProperty;
 
-  ref1 = __nccwpck_require__(4259), isObject = ref1.isObject, isFunction = ref1.isFunction, isEmpty = ref1.isEmpty, getValue = ref1.getValue;
+  ref1 = __nccwpck_require__(1488), isObject = ref1.isObject, isFunction = ref1.isFunction, isEmpty = ref1.isEmpty, getValue = ref1.getValue;
 
   XMLElement = null;
 
@@ -27114,19 +27141,19 @@ module.exports.jsonText = jsonText;
       this.children = [];
       this.baseURI = null;
       if (!XMLElement) {
-        XMLElement = __nccwpck_require__(2262);
-        XMLCData = __nccwpck_require__(5830);
-        XMLComment = __nccwpck_require__(4167);
-        XMLDeclaration = __nccwpck_require__(3832);
-        XMLDocType = __nccwpck_require__(2371);
-        XMLRaw = __nccwpck_require__(7432);
-        XMLText = __nccwpck_require__(4982);
-        XMLProcessingInstruction = __nccwpck_require__(8951);
-        XMLDummy = __nccwpck_require__(9230);
-        NodeType = __nccwpck_require__(7777);
-        XMLNodeList = __nccwpck_require__(7289);
-        XMLNamedNodeMap = __nccwpck_require__(4533);
-        DocumentPosition = __nccwpck_require__(2273);
+        XMLElement = __nccwpck_require__(299);
+        XMLCData = __nccwpck_require__(1232);
+        XMLComment = __nccwpck_require__(1187);
+        XMLDeclaration = __nccwpck_require__(3727);
+        XMLDocType = __nccwpck_require__(4923);
+        XMLRaw = __nccwpck_require__(2321);
+        XMLText = __nccwpck_require__(5630);
+        XMLProcessingInstruction = __nccwpck_require__(6523);
+        XMLDummy = __nccwpck_require__(5907);
+        NodeType = __nccwpck_require__(4601);
+        XMLNodeList = __nccwpck_require__(7951);
+        XMLNamedNodeMap = __nccwpck_require__(597);
+        DocumentPosition = __nccwpck_require__(9511);
       }
     }
 
@@ -27859,7 +27886,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 7289:
+/***/ 7951:
 /***/ (function(module) {
 
 // Generated by CoffeeScript 1.12.7
@@ -27894,7 +27921,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 8951:
+/***/ 6523:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -27903,9 +27930,9 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  XMLCharacterData = __nccwpck_require__(7269);
+  XMLCharacterData = __nccwpck_require__(8557);
 
   module.exports = XMLProcessingInstruction = (function(superClass) {
     extend(XMLProcessingInstruction, superClass);
@@ -27950,7 +27977,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 7432:
+/***/ 2321:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -27959,9 +27986,9 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  XMLNode = __nccwpck_require__(352);
+  XMLNode = __nccwpck_require__(8918);
 
   module.exports = XMLRaw = (function(superClass) {
     extend(XMLRaw, superClass);
@@ -27992,7 +28019,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 5364:
+/***/ 6278:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -28001,11 +28028,11 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  XMLWriterBase = __nccwpck_require__(6605);
+  XMLWriterBase = __nccwpck_require__(2050);
 
-  WriterState = __nccwpck_require__(9461);
+  WriterState = __nccwpck_require__(4260);
 
   module.exports = XMLStreamWriter = (function(superClass) {
     extend(XMLStreamWriter, superClass);
@@ -28175,7 +28202,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 1393:
+/***/ 8433:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -28184,7 +28211,7 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  XMLWriterBase = __nccwpck_require__(6605);
+  XMLWriterBase = __nccwpck_require__(2050);
 
   module.exports = XMLStringWriter = (function(superClass) {
     extend(XMLStringWriter, superClass);
@@ -28217,7 +28244,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 2652:
+/***/ 2033:
 /***/ (function(module) {
 
 // Generated by CoffeeScript 1.12.7
@@ -28464,7 +28491,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 4982:
+/***/ 5630:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -28473,9 +28500,9 @@ module.exports.jsonText = jsonText;
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  XMLCharacterData = __nccwpck_require__(7269);
+  XMLCharacterData = __nccwpck_require__(8557);
 
   module.exports = XMLText = (function(superClass) {
     extend(XMLText, superClass);
@@ -28540,7 +28567,7 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 6605:
+/***/ 2050:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
@@ -28548,37 +28575,37 @@ module.exports.jsonText = jsonText;
   var NodeType, WriterState, XMLCData, XMLComment, XMLDTDAttList, XMLDTDElement, XMLDTDEntity, XMLDTDNotation, XMLDeclaration, XMLDocType, XMLDummy, XMLElement, XMLProcessingInstruction, XMLRaw, XMLText, XMLWriterBase, assign,
     hasProp = {}.hasOwnProperty;
 
-  assign = __nccwpck_require__(4259).assign;
+  assign = __nccwpck_require__(1488).assign;
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  XMLDeclaration = __nccwpck_require__(3832);
+  XMLDeclaration = __nccwpck_require__(3727);
 
-  XMLDocType = __nccwpck_require__(2371);
+  XMLDocType = __nccwpck_require__(4923);
 
-  XMLCData = __nccwpck_require__(5830);
+  XMLCData = __nccwpck_require__(1232);
 
-  XMLComment = __nccwpck_require__(4167);
+  XMLComment = __nccwpck_require__(1187);
 
-  XMLElement = __nccwpck_require__(2262);
+  XMLElement = __nccwpck_require__(299);
 
-  XMLRaw = __nccwpck_require__(7432);
+  XMLRaw = __nccwpck_require__(2321);
 
-  XMLText = __nccwpck_require__(4982);
+  XMLText = __nccwpck_require__(5630);
 
-  XMLProcessingInstruction = __nccwpck_require__(8951);
+  XMLProcessingInstruction = __nccwpck_require__(6523);
 
-  XMLDummy = __nccwpck_require__(9230);
+  XMLDummy = __nccwpck_require__(5907);
 
-  XMLDTDAttList = __nccwpck_require__(720);
+  XMLDTDAttList = __nccwpck_require__(4946);
 
-  XMLDTDElement = __nccwpck_require__(5965);
+  XMLDTDElement = __nccwpck_require__(3168);
 
-  XMLDTDEntity = __nccwpck_require__(3645);
+  XMLDTDEntity = __nccwpck_require__(9691);
 
-  XMLDTDNotation = __nccwpck_require__(7341);
+  XMLDTDNotation = __nccwpck_require__(7818);
 
-  WriterState = __nccwpck_require__(9461);
+  WriterState = __nccwpck_require__(4260);
 
   module.exports = XMLWriterBase = (function() {
     function XMLWriterBase(options) {
@@ -28975,28 +29002,28 @@ module.exports.jsonText = jsonText;
 
 /***/ }),
 
-/***/ 4312:
+/***/ 4730:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 // Generated by CoffeeScript 1.12.7
 (function() {
   var NodeType, WriterState, XMLDOMImplementation, XMLDocument, XMLDocumentCB, XMLStreamWriter, XMLStringWriter, assign, isFunction, ref;
 
-  ref = __nccwpck_require__(4259), assign = ref.assign, isFunction = ref.isFunction;
+  ref = __nccwpck_require__(1488), assign = ref.assign, isFunction = ref.isFunction;
 
-  XMLDOMImplementation = __nccwpck_require__(424);
+  XMLDOMImplementation = __nccwpck_require__(7443);
 
-  XMLDocument = __nccwpck_require__(8051);
+  XMLDocument = __nccwpck_require__(6791);
 
-  XMLDocumentCB = __nccwpck_require__(8189);
+  XMLDocumentCB = __nccwpck_require__(718);
 
-  XMLStringWriter = __nccwpck_require__(1393);
+  XMLStringWriter = __nccwpck_require__(8433);
 
-  XMLStreamWriter = __nccwpck_require__(5364);
+  XMLStreamWriter = __nccwpck_require__(6278);
 
-  NodeType = __nccwpck_require__(7777);
+  NodeType = __nccwpck_require__(4601);
 
-  WriterState = __nccwpck_require__(9461);
+  WriterState = __nccwpck_require__(4260);
 
   module.exports.create = function(name, xmldec, doctype, options) {
     var doc, root;
@@ -29211,7 +29238,7 @@ module.exports = require("util");;
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(1739);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(7209);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/dd-test-results/lib/main.js
+++ b/dd-test-results/lib/main.js
@@ -55,6 +55,7 @@ function findTestReports(testReportFile) {
 }
 run_1.run(new client_1.DataDogClient(core.getInput('dd-api-key', { required: true })), {
     metricName: core.getInput('dd-metric-name', { required: true }),
+    tags: core.getMultilineInput('dd-tags', { required: false }),
     host: core.getInput('dd-host', { required: true }),
     testFramework: core.getInput('test-framework', { required: true }),
     testReportFiles: findTestReports(core.getInput('test-report-file', { required: true })),

--- a/dd-test-results/lib/run.js
+++ b/dd-test-results/lib/run.js
@@ -51,7 +51,7 @@ function run(client, inputs) {
         let allMetrics = [];
         for (const testReportFile of yield inputs.testReportFiles) {
             const testResults = parse(inputs.testFramework, testReportFile);
-            const taggedTestCases = tagging_1.tagTestResults(testResults, inputs.testTagsFile);
+            const taggedTestCases = tagging_1.tagTestResults(inputs.tags, testResults, inputs.testTagsFile);
             const metrics = metrics_1.buildAllMetrics(taggedTestCases, inputs.metricName, inputs.host);
             allMetrics = [...allMetrics, ...metrics];
         }

--- a/dd-test-results/lib/tagging.js
+++ b/dd-test-results/lib/tagging.js
@@ -4,15 +4,26 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.tagTestResults = exports.loadTagsFromFile = void 0;
-function tagTestCases(testResults, testResultsTags) {
+function tagTestCases(tags, testResults, testResultsTags) {
     return testResults.testSuites
-        .map(testSuite => testSuite.testCases.map(testCase => tagTestCase(testSuite, testCase, testResultsTags)))
+        .map(testSuite => testSuite.testCases.map(testCase => tagTestCase(tags, testSuite, testCase, testResultsTags)))
         .reduce((total, current) => [...total, ...current]);
 }
-function tagTestCase(testSuite, testCase, testResultsTags) {
+function tagTestCase(tags, testSuite, testCase, testResultsTags) {
     const testSuiteTags = testResultsTags.suites.find(testSuiteTags => testSuiteTags.name === testSuite.name);
     const testCaseTags = testSuiteTags === null || testSuiteTags === void 0 ? void 0 : testSuiteTags.cases.find(testCaseTags => testCaseTags.name === testCase.name);
-    return Object.assign(Object.assign({}, testCase), { tags: Object.assign(Object.assign(Object.assign({}, testResultsTags.tags), testSuiteTags === null || testSuiteTags === void 0 ? void 0 : testSuiteTags.tags), testCaseTags === null || testCaseTags === void 0 ? void 0 : testCaseTags.tags) });
+    return Object.assign(Object.assign({}, testCase), { tags: Object.assign(Object.assign(Object.assign({}, testSuiteTags === null || testSuiteTags === void 0 ? void 0 : testSuiteTags.tags), testCaseTags === null || testCaseTags === void 0 ? void 0 : testCaseTags.tags), parseTags(tags)) });
+}
+function parseTags(rawTags) {
+    const r = {};
+    rawTags
+        .filter(rawTag => rawTag.includes(':'))
+        .forEach(rawTag => {
+        const key = rawTag.split(':')[0];
+        const value = rawTag.substring(key.length + 1);
+        r[key] = value;
+    });
+    return r;
 }
 const fs_1 = __importDefault(require("fs"));
 function loadTagsFromFile(filePath) {
@@ -21,7 +32,7 @@ function loadTagsFromFile(filePath) {
     return json;
 }
 exports.loadTagsFromFile = loadTagsFromFile;
-function tagTestResults(testResults, tagsFile) {
-    return tagTestCases(testResults, loadTagsFromFile(tagsFile));
+function tagTestResults(tags, testResults, tagsFile) {
+    return tagTestCases(tags, testResults, loadTagsFromFile(tagsFile));
 }
 exports.tagTestResults = tagTestResults;

--- a/dd-test-results/package-lock.json
+++ b/dd-test-results/package-lock.json
@@ -8,7 +8,7 @@
             "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@actions/core": "^1.3.0",
+                "@actions/core": "^1.4.0",
                 "@actions/glob": "^0.2.0",
                 "@actions/http-client": "^1.0.11",
                 "junitxml-to-javascript": "^1.1.4",
@@ -34,9 +34,9 @@
             }
         },
         "node_modules/@actions/core": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.3.0.tgz",
-            "integrity": "sha512-xxtX0Cwdhb8LcgatfJkokqT8KzPvcIbwL9xpLU09nOwBzaStbfm0dNncsP0M4us+EpoPdWy7vbzU5vSOH7K6pg=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.4.0.tgz",
+            "integrity": "sha512-CGx2ilGq5i7zSLgiiGUtBCxhRRxibJYU6Fim0Q1Wg2aQL2LTnF27zbqZOrxfvFQ55eSBW0L8uVStgtKMpa0Qlg=="
         },
         "node_modules/@actions/glob": {
             "version": "0.2.0",
@@ -8968,9 +8968,9 @@
     },
     "dependencies": {
         "@actions/core": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.3.0.tgz",
-            "integrity": "sha512-xxtX0Cwdhb8LcgatfJkokqT8KzPvcIbwL9xpLU09nOwBzaStbfm0dNncsP0M4us+EpoPdWy7vbzU5vSOH7K6pg=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.4.0.tgz",
+            "integrity": "sha512-CGx2ilGq5i7zSLgiiGUtBCxhRRxibJYU6Fim0Q1Wg2aQL2LTnF27zbqZOrxfvFQ55eSBW0L8uVStgtKMpa0Qlg=="
         },
         "@actions/glob": {
             "version": "0.2.0",

--- a/dd-test-results/package.json
+++ b/dd-test-results/package.json
@@ -24,7 +24,7 @@
         "all": "npm run build && npm run format && ncc build lib/main.js && npm run lint && npm test"
     },
     "dependencies": {
-        "@actions/core": "^1.3.0",
+        "@actions/core": "^1.4.0",
         "@actions/glob": "^0.2.0",
         "@actions/http-client": "^1.0.11",
         "junitxml-to-javascript": "^1.1.4",

--- a/dd-test-results/src/main.ts
+++ b/dd-test-results/src/main.ts
@@ -25,6 +25,7 @@ async function findTestReports(testReportFile: string): Promise<string[]> {
 
 run(new DataDogClient(core.getInput('dd-api-key', {required: true})), {
   metricName: core.getInput('dd-metric-name', {required: true}),
+  tags: core.getMultilineInput('dd-tags', {required: false}),
   host: core.getInput('dd-host', {required: true}),
   testFramework: core.getInput('test-framework', {required: true}),
   testReportFiles: findTestReports(

--- a/dd-test-results/src/main.ts
+++ b/dd-test-results/src/main.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import {DataDogClient} from './client'
 import {run} from './run'
-import glob from '@actions/glob'
+import * as glob from '@actions/glob'
 import {stat} from 'fs'
 import {promisify} from 'util'
 const stats = promisify(stat)

--- a/dd-test-results/src/run.ts
+++ b/dd-test-results/src/run.ts
@@ -7,6 +7,7 @@ import {buildAllMetrics} from './metrics'
 
 interface Inputs {
   metricName: string
+  tags: string[]
   host: string
   testFramework: string
   testReportFiles: Promise<string[]>
@@ -34,7 +35,11 @@ export async function run(
 
   for (const testReportFile of await inputs.testReportFiles) {
     const testResults: TestResults = parse(inputs.testFramework, testReportFile)
-    const taggedTestCases = tagTestResults(testResults, inputs.testTagsFile)
+    const taggedTestCases = tagTestResults(
+      inputs.tags,
+      testResults,
+      inputs.testTagsFile
+    )
     const metrics = buildAllMetrics(
       taggedTestCases,
       inputs.metricName,

--- a/dd-test-results/src/tagging.ts
+++ b/dd-test-results/src/tagging.ts
@@ -1,17 +1,19 @@
 function tagTestCases(
+  tags: string[],
   testResults: TestResults,
   testResultsTags: TestResultsTags
 ): TaggedTestCase[] {
   return testResults.testSuites
     .map(testSuite =>
       testSuite.testCases.map(testCase =>
-        tagTestCase(testSuite, testCase, testResultsTags)
+        tagTestCase(tags, testSuite, testCase, testResultsTags)
       )
     )
     .reduce((total, current) => [...total, ...current])
 }
 
 function tagTestCase(
+  tags: string[],
   testSuite: TestSuite,
   testCase: TestCase,
   testResultsTags: TestResultsTags
@@ -26,11 +28,25 @@ function tagTestCase(
   return {
     ...testCase,
     tags: {
-      ...testResultsTags.tags,
       ...testSuiteTags?.tags,
-      ...testCaseTags?.tags
+      ...testCaseTags?.tags,
+      ...parseTags(tags)
     }
   }
+}
+
+function parseTags(rawTags: string[]): Record<string, string> {
+  const r: Record<string, string> = {}
+
+  rawTags
+    .filter(rawTag => rawTag.includes(':'))
+    .forEach(rawTag => {
+      const key = rawTag.split(':')[0]
+      const value = rawTag.substring(key.length + 1)
+      r[key] = value
+    })
+
+  return r
 }
 
 import fs from 'fs'
@@ -42,8 +58,9 @@ export function loadTagsFromFile(filePath: string): TestResultsTags {
 }
 
 export function tagTestResults(
+  tags: string[],
   testResults: TestResults,
   tagsFile: string
 ): TaggedTestCase[] {
-  return tagTestCases(testResults, loadTagsFromFile(tagsFile))
+  return tagTestCases(tags, testResults, loadTagsFromFile(tagsFile))
 }

--- a/dd-test-results/tests/resources/test-results-tags.json
+++ b/dd-test-results/tests/resources/test-results-tags.json
@@ -1,13 +1,10 @@
 {
-    "tags": {
-        "team": "a",
-        "test_classification": "smoke"
-    },
     "suites": [
         {
             "name": "com.example.SampleTests",
             "tags": {
-                "test_suite": "sample_tests"
+                "test_suite": "sample_tests",
+                "test_classification": "smoke"
             },
             "cases": [
                 {

--- a/dd-test-results/tests/tagging.test.ts
+++ b/dd-test-results/tests/tagging.test.ts
@@ -18,13 +18,18 @@ describe('tagging', () => {
     }
 
     const tagsFile = path.join(__dirname, 'resources', 'test-results-tags.json')
-    const taggedTestCases = tagTestResults(testResults, tagsFile)
+    const taggedTestCases = tagTestResults(
+      ['platform:android'],
+      testResults,
+      tagsFile
+    )
 
     expect(taggedTestCases).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           ...testCase,
           tags: {
+            platform: 'android',
             team: 'c',
             test_case: 'sampleTestName',
             test_classification: 'smoke',


### PR DESCRIPTION
## Changes

Accept tags via YML input & JSON file

This enables better support for both statically defined tags (JSON) and dynamically computed ones (YML via expression syntax)

Bonus points: fix incorrect glob import