### PR TITLE
Fixing result parser on mstest

### DIFF
--- a/dd-test-results/dist/index.js
+++ b/dd-test-results/dist/index.js
@@ -289,7 +289,7 @@ function parseTestCase(testCaseElement) {
     const testCase = {
         name: testCaseElement.testName,
         duration: convertDurationToSeconds(testCaseElement.duration),
-        result: testCaseElement.outcome
+        result: testCaseElement.outcome == 'Passed' ? 'succeeded' : 'failed'
     };
     return testCase;
 }

--- a/dd-test-results/lib/mstest-test-result-parser.js
+++ b/dd-test-results/lib/mstest-test-result-parser.js
@@ -52,7 +52,7 @@ function parseTestCase(testCaseElement) {
     const testCase = {
         name: testCaseElement.testName,
         duration: convertDurationToSeconds(testCaseElement.duration),
-        result: testCaseElement.outcome
+        result: testCaseElement.outcome == 'Passed' ? 'succeeded' : 'failed'
     };
     return testCase;
 }

--- a/dd-test-results/src/mstest-test-result-parser.ts
+++ b/dd-test-results/src/mstest-test-result-parser.ts
@@ -47,7 +47,7 @@ function parseTestCase(testCaseElement): TestCase {
   const testCase: TestCase = {
     name: testCaseElement.testName,
     duration: convertDurationToSeconds(testCaseElement.duration),
-    result: testCaseElement.outcome
+    result: testCaseElement.outcome == 'Passed' ? 'succeeded' : 'failed'
   }
   return testCase
 }

--- a/dd-test-results/tests/mstest-test-result-parser.test.ts
+++ b/dd-test-results/tests/mstest-test-result-parser.test.ts
@@ -22,13 +22,13 @@ describe('MSTest Test Result Parser', () => {
           'CreateNewTicket_VerifyTicketShownInRequestList'
         )
         expect(r.testSuites[0].testCases[0].duration).toEqual(34)
-        expect(r.testSuites[0].testCases[0].result).toEqual('Passed')
+        expect(r.testSuites[0].testCases[0].result).toEqual('succeeded')
         // Second test case
         expect(r.testSuites[1].testCases[0].name).toEqual(
           'OpenHelpCenter_OpenArticle_VerifyContentsDisplayed'
         )
         expect(r.testSuites[1].testCases[0].duration).toEqual(47)
-        expect(r.testSuites[1].testCases[0].result).toEqual('Passed')
+        expect(r.testSuites[1].testCases[0].result).toEqual('succeeded')
         done()
       })
       .catch(e => {


### PR DESCRIPTION
Fixing result parser on mstest