### PR TITLE
Add platform data subgraph integration GA

### DIFF
--- a/platform-data-subgraph-integration/README.md
+++ b/platform-data-subgraph-integration/README.md
@@ -1,0 +1,30 @@
+# Platform Data Subgraph Integration
+
+This GitHub action provides the common logic that is required to add subgraphs to the federated GraphQL Gateway.
+
+In order to use it, add a step to your default workflow, create a new one with the following content:
+
+```
+name: Platform Data Subgraph Integration
+on: [push, pull_request]
+
+jobs:
+  main:
+    runs-on: [self-hosted, zendesk-stable]
+
+    steps:
+      - uses: zendesk/checkout@v2
+
+      - name: <Your service name> subgraph schema integration
+        uses: zendesk/ga/platform-data-subgraph-integration@v1
+        env:
+          APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
+        with:
+          subgraph-name: <your service subgraph name>
+          schema-path: <path to your>/federated-schema.graphql
+```
+
+The action will perform the following tasks, though the One-Graph team might introduce other actions in the future.
+
+- Use Apollo Rover CLI to check any change to the subgraph schema. Pull requests will fail if the schema is invalid and cannot be merged.
+- Publish the subgraph schema to the @main platform data graph variant on merges to the repository default branch

--- a/platform-data-subgraph-integration/action.yml
+++ b/platform-data-subgraph-integration/action.yml
@@ -1,0 +1,53 @@
+name: Platform Data Subgraph Integration
+description: Perform different action to support integrating subgraphs into the platform data graph
+author: OneGraph team
+branding:
+  color: pink
+  icon: box
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Rover
+      shell: bash
+      run: |
+        curl -sSL https://rover.apollo.dev/nix/v0.2.0 | sh
+
+        # Add Rover to the $GITHUB_PATH so it can be used in another step
+        # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+        echo "$HOME/.rover/bin" >> $GITHUB_PATH
+    - name: Run subgraph check
+      shell: bash
+      run: |
+        rover subgraph check ${{ inputs.graph-id }}@${{ inputs.graph-variant }} \
+          --schema ${{ inputs.schema-path }} \
+          --name ${{ inputs.subgraph-name }}
+    - name: Publish subgraph
+      shell: bash
+      # GA doesn't support conditions in composite actions
+      run: |
+        if [[ ${{ github.ref }} == ${{ github.event.repository.default_branch }} ]]
+        then
+          rover subgraph publish ${{ inputs.graph-id }}@${{ inputs.graph-variant }} \
+            --schema ${{ inputs.schema-path }} \
+            --name ${{ inputs.subgraph-name }}
+        fi
+inputs:
+  subgraph-name:
+    description: >
+      The name of the subgraph
+    required: true
+  schema-path:
+    description: >
+      Schema path
+    required: true
+  graph-id:
+    description: >
+      Graph ID
+    required: false
+    default: platform-data-graph
+  graph-variant:
+    description: >
+      Graph variant
+    required: false
+    default: main


### PR DESCRIPTION
# Description

This PRs adds a new GitHub action to the repository. GraphQL services that will be part of the federated GraphQL Gateway will need to use this GA to run checks and publish the schema to Apollo Studio.

Please, have a look at the [README](https://github.com/zendesk/ga/blob/nogates/one-graph-ga-action/platform-data-subgraph-integration/README.md) to know more about how the action works.