### PR TITLE
feat: add image-tag-identifier parameter

### DIFF
--- a/docker-build-multiarch/README.md
+++ b/docker-build-multiarch/README.md
@@ -9,7 +9,7 @@ action.
 It builds and pushes image in this format:
 
 ```
-${ inputs.image-name }:${ github.sha }-${ inputs.architecture }
+${ inputs.image-name }:${ inputs.image-tag-identifier }-${ inputs.architecture }
 ```
 
 Note: This action intentionally allows building only single architecture at the time, even when `buildx` 
@@ -19,15 +19,16 @@ may also use own host runner, this will allow to use it.
 
 ## Parameters
 
-| Parameter | | Description |
-|--|--|--|
-| `architecture` | required | Architecture to build image for without the os prefix (only linux). E.g. `amd64`, `arm64` |
-| `working-directory` | optiona, default `.` | Build in different working directory than the root of the repository |
-| `image-name` | optional, default `env.IMAGE_NAME` | The full name of the image without tag. |
-| `docker-args` | optional, default: `''` | additional arguments to the docker build command. Can be used to add `--build-args`, `--cache-from`, etc. Note that `buildx` automatically pull images when using `--cache-from`. |
-| `push` | optional, default: `true` | whether to push the build images or not. Accepts string of `"true"` or `"false"`. |
-| `dockerfile` | optional, default: `Dockerfile` | path to Dockerfile to use |
-| `add-revision-label` | optional, default: `true` | whether to add the revision label with current sha to the image |
+| Parameter              |                                    | Description                                                                                                                                                                       |
+| ---------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `architecture`         | required                           | Architecture to build image for without the os prefix (only linux). E.g. `amd64`, `arm64`                                                                                         |
+| `working-directory`    | optiona, default `.`               | Build in different working directory than the root of the repository                                                                                                              |
+| `image-name`           | optional, default `env.IMAGE_NAME` | The full name of the image without tag.                                                                                                                                           |
+| `image-tag-identifier` | optional, default `github.sha`     | Image tag to identify this build when creating the mutliarch manifest. Use the same value in the docker-create-manifest action.                                                   |
+| `docker-args`          | optional, default: `''`            | Additional arguments to the docker build command. Can be used to add `--build-args`, `--cache-from`, etc. Note that `buildx` automatically pull images when using `--cache-from`. |
+| `push`                 | optional, default: `true`          | Whether to push the build images or not. Accepts string of `"true"` or `"false"`.                                                                                                 |
+| `dockerfile`           | optional, default: `Dockerfile`    | Path to Dockerfile to use                                                                                                                                                         |
+| `add-revision-label`   | optional, default: `true`          | Whether to add the revision label with current sha to the image                                                                                                                   |
 
 ## Basic example
 

--- a/docker-build-multiarch/action.yaml
+++ b/docker-build-multiarch/action.yaml
@@ -13,6 +13,10 @@ inputs:
     description: Image name without tag to use when building and pushing the image. Defaults to env IMAGE_NAME
     required: false
     default: ""
+  image-tag-identifier:
+    description: Image tag to identify this build when creating the mutliarch manifest. Defaults to github.sha.
+    required: false
+    default: ""
   docker-args:
     description: Optional docker build arguments like --build-arg, --cache-from, ...
     required: false
@@ -55,7 +59,8 @@ runs:
           exit 1
         fi
 
-        IMAGE_TAG=${{ github.sha }}-${{ inputs.architecture }}
+        IMAGE_TAG_IDENTIFIER=${{ inputs.image-tag-identifier == '' && github.sha || inputs.image-tag-identifier }}
+        IMAGE_TAG=$IMAGE_TAG_IDENTIFIER-${{ inputs.architecture }}
         FULL_IMAGE_NAME=$IMAGE_NAME:$IMAGE_TAG
 
         REVISION_LABEL_ARG=${{ inputs.add-revision-label == 'true' && format('--label=revision={0}', github.sha) || '' }}

--- a/docker-create-manifest/README.md
+++ b/docker-create-manifest/README.md
@@ -21,17 +21,18 @@ ${ input.image-name }:custom-tag           # for each tag in target-tags
 referencing this list of images:
 
 ```
-${ input.image-name }:${ github.sha }-amd64
-${ input.image-name }:${ github.sha }-arm64
+${ input.image-name }:${ input.image-tag-identifier }-amd64
+${ input.image-name }:${ input.image-tag-identifier }-arm64
 ```
 
 ## Parameters
 
-| Parameter | | Description |
-|--|--|--|
-| `image-name` | optional, default `env.IMAGE_NAME` | The full name of the image without tag. It can be also list of images separated by space. In that case it behaves like the same action is run multiple times for each image with the same target tags. |
-| `target-tags` | optional, default: `github.sha github.ref_name` | Space separated list of tags to create the manifest with. Tags are automatically replaced with `-` for any unsupported character. |
-| `architectures` | optional, default: `amd64 arm64` | Space separated list of architectures to infert the list of source images from. Each architecture will be mapped to `${ input.image-name}:${ github.sha }-<arch>` image in the list. |
+| Parameter              |                                                 | Description                                                                                                                                                                                            |
+| ---------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `image-name`           | optional, default `env.IMAGE_NAME`              | The full name of the image without tag. It can be also list of images separated by space. In that case it behaves like the same action is run multiple times for each image with the same target tags. |
+| `image-tag-identifier` | optional, default `github.sha`                  | Image tag to identify this build when creating the mutliarch manifest. Use the same value in the docker-build-multiarch action.                                                                        |
+| `target-tags`          | optional, default: `github.sha github.ref_name` | Space separated list of tags to create the manifest with. Tags are automatically replaced with `-` for any unsupported character.                                                                      |
+| `architectures`        | optional, default: `amd64 arm64`                | Space separated list of architectures to infert the list of source images from. Each architecture will be mapped to `${ input.image-name}:${ github.sha }-<arch>` image in the list.                   |
 
 ## Examples
 

--- a/docker-create-manifest/action.yaml
+++ b/docker-create-manifest/action.yaml
@@ -6,6 +6,10 @@ inputs:
     description: Image name or image names (space separated) without tag to use when building and pushing the image. Defaults to env IMAGE_NAME
     required: false
     default: ""
+  image-tag-identifier:
+    description: Image tag to identify the source images. Defaults to github.sha.
+    required: false
+    default: ""
   target-tags:
     description: Space separated list of tags to use for the resulting manifest to add to the implict tags. Defaults to commit sha and branch name.
     required: false
@@ -26,7 +30,7 @@ runs:
           TARGET_IMAGE=$1
           echo "Target image: $TARGET_IMAGE"
 
-          SOURCE_TAG_PREFIX=${{ github.sha }}
+          SOURCE_TAG_PREFIX=${{ inputs.image-tag-identifier == '' && github.sha || inputs.image-tag-identifier }}
           SOURCE_IMAGES=""
           for ARCH in ${{ inputs.architectures }}; do
             ARCH_SOURCE_IMAGE=$IMAGE_NAME:$SOURCE_TAG_PREFIX-$ARCH


### PR DESCRIPTION
To allow building image that use different Dockerfiles or configuration per tag, instead of per image name.

Add image-tag-identifier to the parameters to differentiate the intermediary per-arch images, and to use them as source when creating the multiarch manifest.